### PR TITLE
[codex] Fix update policy limit invariant

### DIFF
--- a/programs/solana-guard/src/instructions/update_policy.rs
+++ b/programs/solana-guard/src/instructions/update_policy.rs
@@ -13,19 +13,20 @@ pub fn handler(
     is_active: Option<bool>,
 ) -> Result<()> {
     let policy = &mut ctx.accounts.policy;
+    let new_max_spend_per_tx = max_spend_per_tx.unwrap_or(policy.max_spend_per_tx);
+    let new_daily_limit = daily_limit.unwrap_or(policy.daily_limit);
 
-    if let Some(max_per_tx) = max_spend_per_tx {
-        require!(max_per_tx > 0, SolanaGuardError::InvalidSpendingLimit);
-        policy.max_spend_per_tx = max_per_tx;
-    }
+    require!(
+        new_max_spend_per_tx > 0,
+        SolanaGuardError::InvalidSpendingLimit
+    );
+    require!(
+        new_daily_limit >= new_max_spend_per_tx,
+        SolanaGuardError::InvalidDailyLimit
+    );
 
-    if let Some(daily) = daily_limit {
-        require!(
-            daily >= policy.max_spend_per_tx,
-            SolanaGuardError::InvalidDailyLimit
-        );
-        policy.daily_limit = daily;
-    }
+    policy.max_spend_per_tx = new_max_spend_per_tx;
+    policy.daily_limit = new_daily_limit;
 
     if let Some(protocols) = allowed_protocols {
         require!(


### PR DESCRIPTION
## Summary

- Computes the proposed final per-transaction and daily limits before mutating policy state.
- Validates `daily_limit >= max_spend_per_tx` against the final values for every update path.

## Why

Updating only `max_spend_per_tx` could previously leave an existing policy with `max_spend_per_tx > daily_limit`, even though `set_policy` rejects that state.

## Validation

- `rustup run 1.89.0 cargo test`

Closes #4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for spending limits when updating policies to ensure max spend per transaction and daily limits maintain consistent and valid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->