### PR TITLE
[codex] Scope agent nonce by owner

### DIFF
--- a/programs/solana-guard/src/instructions/register_agent.rs
+++ b/programs/solana-guard/src/instructions/register_agent.rs
@@ -15,6 +15,7 @@ pub fn handler(ctx: Context<RegisterAgent>) -> Result<()> {
     agent_config.registered_at = clock.unix_timestamp;
     agent_config.bump = ctx.bumps.agent_config;
 
+    agent_nonce.owner = ctx.accounts.owner.key();
     agent_nonce.agent = ctx.accounts.agent.key();
     agent_nonce.nonce = 0;
     agent_nonce.bump = ctx.bumps.agent_nonce;
@@ -53,7 +54,7 @@ pub struct RegisterAgent<'info> {
         init,
         payer = owner,
         space = 8 + AgentNonce::INIT_SPACE,
-        seeds = [NONCE_SEED, agent.key().as_ref()],
+        seeds = [NONCE_SEED, owner.key().as_ref(), agent.key().as_ref()],
         bump,
     )]
     pub agent_nonce: Account<'info, AgentNonce>,

--- a/programs/solana-guard/src/instructions/validate_and_execute.rs
+++ b/programs/solana-guard/src/instructions/validate_and_execute.rs
@@ -114,7 +114,12 @@ pub struct ValidateAndExecute<'info> {
         init,
         payer = agent,
         space = 8 + TransactionLog::INIT_SPACE,
-        seeds = [TX_LOG_SEED, agent.key().as_ref(), &agent_nonce.nonce.to_le_bytes()],
+        seeds = [
+            TX_LOG_SEED,
+            owner.key().as_ref(),
+            agent.key().as_ref(),
+            &agent_nonce.nonce.to_le_bytes(),
+        ],
         bump,
     )]
     pub tx_log: Account<'info, TransactionLog>,
@@ -122,8 +127,10 @@ pub struct ValidateAndExecute<'info> {
     /// Nonce tracker for the agent
     #[account(
         mut,
-        seeds = [NONCE_SEED, agent.key().as_ref()],
+        seeds = [NONCE_SEED, owner.key().as_ref(), agent.key().as_ref()],
         bump = agent_nonce.bump,
+        constraint = agent_nonce.owner == owner.key() @ SolanaGuardError::UnauthorizedOwner,
+        constraint = agent_nonce.agent == agent.key() @ SolanaGuardError::UnauthorizedAgent,
     )]
     pub agent_nonce: Account<'info, AgentNonce>,
 

--- a/programs/solana-guard/src/state.rs
+++ b/programs/solana-guard/src/state.rs
@@ -66,10 +66,11 @@ pub struct TransactionLog {
     pub bump: u8,
 }
 
-/// Global nonce tracker per agent for transaction log indexing
+/// Nonce tracker per owner/agent pair for transaction log indexing
 #[account]
 #[derive(InitSpace)]
 pub struct AgentNonce {
+    pub owner: Pubkey,
     pub agent: Pubkey,
     pub nonce: u64,
     pub bump: u8,

--- a/programs/solana-guard/tests/test_initialize.rs
+++ b/programs/solana-guard/tests/test_initialize.rs
@@ -40,7 +40,7 @@ fn test_register_agent() {
         &program_id,
     );
     let (agent_nonce_pda, _) = Pubkey::find_program_address(
-        &[b"nonce", agent.pubkey().as_ref()],
+        &[b"nonce", owner.pubkey().as_ref(), agent.pubkey().as_ref()],
         &program_id,
     );
 


### PR DESCRIPTION
## Summary

- Scopes `AgentNonce` accounts by `(owner, agent)` instead of only `agent`.
- Adds owner/agent constraints to nonce validation during execution.
- Scopes transaction log PDAs by `(owner, agent, nonce)` so logs follow the owner-scoped nonce model.
- Updates the LiteSVM registration test PDA derivation for the new nonce seeds.

## Why

The previous nonce PDA made an agent pubkey globally unique across all owners, while `AgentConfig` and `Policy` were owner-scoped. That prevented the same agent pubkey from being registered under multiple owners.

## Validation

- `rustup run 1.89.0 cargo test`

Closes #5
