### PR TITLE
[codex] Emit events for rejected validations

### DIFF
--- a/programs/solana-guard/src/constants.rs
+++ b/programs/solana-guard/src/constants.rs
@@ -8,3 +8,10 @@ pub const NONCE_SEED: &[u8] = b"nonce";
 
 /// Time constants
 pub const SECONDS_PER_DAY: i64 = 86_400;
+
+/// Rejection reason codes emitted in TransactionRejected events
+pub const REJECTION_AGENT_NOT_ACTIVE: u8 = 1;
+pub const REJECTION_POLICY_NOT_ACTIVE: u8 = 2;
+pub const REJECTION_EXCEEDS_PER_TX_LIMIT: u8 = 3;
+pub const REJECTION_EXCEEDS_DAILY_LIMIT: u8 = 4;
+pub const REJECTION_PROTOCOL_NOT_ALLOWED: u8 = 5;

--- a/programs/solana-guard/src/instructions/validate_and_execute.rs
+++ b/programs/solana-guard/src/instructions/validate_and_execute.rs
@@ -23,39 +23,91 @@ pub fn handler(
     let tx_log = &mut ctx.accounts.tx_log;
     let agent_nonce = &mut ctx.accounts.agent_nonce;
     let clock = Clock::get()?;
+    let now = clock.unix_timestamp;
 
     // ---- Check 1: Agent must be active ----
-    require!(agent_config.is_active, SolanaGuardError::AgentNotActive);
+    if !agent_config.is_active {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            policy.daily_spent,
+            now,
+            REJECTION_AGENT_NOT_ACTIVE,
+        );
+        return err!(SolanaGuardError::AgentNotActive);
+    }
 
     // ---- Check 2: Policy must be active ----
-    require!(policy.is_active, SolanaGuardError::PolicyNotActive);
+    if !policy.is_active {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            policy.daily_spent,
+            now,
+            REJECTION_POLICY_NOT_ACTIVE,
+        );
+        return err!(SolanaGuardError::PolicyNotActive);
+    }
 
     // ---- Check 3: Per-transaction limit ----
-    require!(
-        amount <= policy.max_spend_per_tx,
-        SolanaGuardError::ExceedsPerTxLimit
-    );
+    if amount > policy.max_spend_per_tx {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            policy.daily_spent,
+            now,
+            REJECTION_EXCEEDS_PER_TX_LIMIT,
+        );
+        return err!(SolanaGuardError::ExceedsPerTxLimit);
+    }
 
     // ---- Check 4: Daily limit (with 24h reset) ----
-    let now = clock.unix_timestamp;
-    if now - policy.day_start >= SECONDS_PER_DAY {
+    let should_reset_day = now - policy.day_start >= SECONDS_PER_DAY;
+    let current_daily_spent = if should_reset_day {
+        0
+    } else {
+        policy.daily_spent
+    };
+
+    if current_daily_spent.checked_add(amount).unwrap_or(u64::MAX) > policy.daily_limit {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            current_daily_spent,
+            now,
+            REJECTION_EXCEEDS_DAILY_LIMIT,
+        );
+        return err!(SolanaGuardError::ExceedsDailyLimit);
+    }
+
+    // ---- Check 5: Protocol allowlist ----
+    if !policy.allowed_protocols.contains(&target_protocol) {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            current_daily_spent,
+            now,
+            REJECTION_PROTOCOL_NOT_ALLOWED,
+        );
+        return err!(SolanaGuardError::ProtocolNotAllowed);
+    }
+
+    // ---- All checks passed — update state ----
+    if should_reset_day {
         // Reset the daily counter — new day
         policy.daily_spent = 0;
         policy.day_start = now;
     }
-
-    require!(
-        policy.daily_spent.checked_add(amount).unwrap_or(u64::MAX) <= policy.daily_limit,
-        SolanaGuardError::ExceedsDailyLimit
-    );
-
-    // ---- Check 5: Protocol allowlist ----
-    require!(
-        policy.allowed_protocols.contains(&target_protocol),
-        SolanaGuardError::ProtocolNotAllowed
-    );
-
-    // ---- All checks passed — update state ----
     policy.daily_spent = policy.daily_spent.checked_add(amount).unwrap();
 
     // Write transaction log
@@ -81,6 +133,27 @@ pub fn handler(
     );
 
     Ok(())
+}
+
+fn emit_rejection(
+    agent_config: &AgentConfig,
+    policy: &Policy,
+    amount: u64,
+    target_protocol: Pubkey,
+    daily_spent: u64,
+    rejected_at: i64,
+    reason_code: u8,
+) {
+    emit!(TransactionRejected {
+        agent: agent_config.agent,
+        owner: agent_config.owner,
+        amount,
+        target_protocol,
+        daily_spent,
+        daily_limit: policy.daily_limit,
+        rejected_at,
+        reason_code,
+    });
 }
 
 #[derive(Accounts)]

--- a/programs/solana-guard/src/state.rs
+++ b/programs/solana-guard/src/state.rs
@@ -66,6 +66,29 @@ pub struct TransactionLog {
     pub bump: u8,
 }
 
+/// Event emitted when a transaction attempt is rejected.
+/// Failed instructions cannot persist TransactionLog accounts, so rejected
+/// attempts are exposed through transaction logs instead.
+#[event]
+pub struct TransactionRejected {
+    /// The agent that attempted this transaction
+    pub agent: Pubkey,
+    /// The owner of the agent
+    pub owner: Pubkey,
+    /// Requested amount in lamports
+    pub amount: u64,
+    /// The target program the agent attempted to interact with
+    pub target_protocol: Pubkey,
+    /// Running daily spend used for the validation
+    pub daily_spent: u64,
+    /// Configured daily limit
+    pub daily_limit: u64,
+    /// Timestamp of rejection
+    pub rejected_at: i64,
+    /// Machine-readable reason code. See constants.rs.
+    pub reason_code: u8,
+}
+
 /// Global nonce tracker per agent for transaction log indexing
 #[account]
 #[derive(InitSpace)]


### PR DESCRIPTION
## Summary

- Adds `TransactionRejected` events for failed validation attempts.
- Emits a machine-readable rejection reason code before each validation error path.
- Keeps approved transactions recorded through `TransactionLog` accounts while rejected attempts are exposed through transaction logs, since failed instructions cannot persist newly initialized accounts.

## Why

`TransactionLog.was_approved` implied rejected attempts were tracked, but all failed `require!` paths rolled back before any account could be written. Emitting rejection events gives indexers and operators an audit signal for failed attempts without pretending failed instructions can persist account state.

## Validation

- `rustup run 1.89.0 cargo test`

Closes #3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced transaction rejection reporting with specific reason codes identifying the cause of rejection: agent status, policy status, per-transaction limits, daily limits, and protocol restrictions.
  * Comprehensive rejection events now include detailed context such as daily spending amount, daily limit, and rejection timestamp for improved transaction visibility and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->