### PR TITLE
Add guarded vault execution and on-chain rejection logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,34 +12,41 @@ AI agents are getting access to user wallets, but there's no on-chain mechanism 
 
 ## The Solution
 
-SolanaGuard is a Solana smart contract (built with Anchor/Rust) that acts as a **deterministic firewall** between AI agents and your funds. Users register an agent, set policies (max spend per tx, daily limit, allowed protocols), and the contract enforces these rules on every transaction.
+SolanaGuard is a Solana smart contract (built with Anchor/Rust) that acts as a **deterministic firewall** between AI agents and your funds. Users register an agent, fund a program-controlled vault, set policies (max spend per tx, daily limit, daily tx cap, allowed protocols, and slippage limit), and the contract enforces these rules while executing each guarded transfer from the vault itself.
 
 **No agent, no backend, and no developer can override them — enforcement happens at the blockchain level.**
 
 ## Features
 
 - 🔐 **Agent Registration** — Bind AI agents to your wallet with PDA-based identity
+- 🏦 **Program Vault** — Funds live in a PDA-controlled vault instead of an agent wallet
 - 📊 **Per-Transaction Limits** — Cap the maximum any single transaction can spend
 - 📅 **Daily Spending Limits** — Automatic 24-hour rolling reset
+- 🔢 **Daily Transaction Caps** — Limit how many approved actions an agent can take per day
 - ✅ **Protocol Allowlisting** — Whitelist only the programs your agent can interact with
+- 📉 **Slippage Limits** — Reject actions when reported slippage exceeds policy
 - 🚨 **Emergency Kill Switch** — Instantly pause any agent with one transaction
-- 📝 **On-chain Audit Trail** — Every transaction logged as a PDA for full transparency
+- 📝 **On-chain Audit Trail** — Every attempt is recorded as a PDA log; rejected attempts also emit events
 - 🔄 **Partial Policy Updates** — Modify individual policy fields without resetting everything
+
+Policy denials are recorded as successful on-chain audit entries with `was_approved = false` and a rejection reason code. This preserves a durable audit trail without moving funds from the guarded vault.
 
 ## Architecture
 
 ```
 ┌─────────────┐     ┌──────────────────┐     ┌─────────────────┐
-│   AI Agent   │────▶│   SolanaGuard    │────▶│  Target Protocol│
+│   AI Agent   │────▶│   SolanaGuard    │────▶│  Target Account │
 │  (e.g. GPT)  │     │  Smart Contract  │     │  (e.g. Jupiter) │
 └─────────────┘     │                  │     └─────────────────┘
                     │  ✓ Agent active? │
                     │  ✓ Under tx max? │
                     │  ✓ Under daily?  │
+                    │  ✓ Under tx/day? │
                     │  ✓ Protocol OK?  │
+                    │  ✓ Slippage OK?  │
                     │                  │
                     │  ❌ REJECT or    │
-                    │  ✅ APPROVE      │
+                    │  ✅ EXECUTE      │
                     └──────────────────┘
 ```
 
@@ -48,10 +55,12 @@ SolanaGuard is a Solana smart contract (built with Anchor/Rust) that acts as a *
 | Instruction | Who Calls | Description |
 |---|---|---|
 | `register_agent` | Owner | Register an AI agent under your ownership |
-| `set_policy` | Owner | Define spending limits and allowed protocols |
-| `validate_and_execute` | Agent | Check transaction against policy before executing |
+| `fund_vault` | Owner | Deposit SOL into the guarded vault |
+| `set_policy` | Owner | Define spending, tx-count, protocol, and slippage limits |
+| `validate_and_execute` | Agent | Enforce policy and execute the guarded transfer from the vault |
 | `toggle_agent` | Owner | Pause/unpause an agent (kill switch) |
 | `update_policy` | Owner | Partially update policy parameters |
+| `withdraw_vault` | Owner | Withdraw unused SOL back from the vault |
 
 ## Quick Start
 

--- a/programs/solana-guard/src/constants.rs
+++ b/programs/solana-guard/src/constants.rs
@@ -5,13 +5,18 @@ pub const AGENT_SEED: &[u8] = b"agent";
 pub const POLICY_SEED: &[u8] = b"policy";
 pub const TX_LOG_SEED: &[u8] = b"tx_log";
 pub const NONCE_SEED: &[u8] = b"nonce";
+pub const VAULT_SEED: &[u8] = b"vault";
 
 /// Time constants
 pub const SECONDS_PER_DAY: i64 = 86_400;
 
 /// Rejection reason codes emitted in TransactionRejected events
+pub const REJECTION_NONE: u8 = 0;
 pub const REJECTION_AGENT_NOT_ACTIVE: u8 = 1;
 pub const REJECTION_POLICY_NOT_ACTIVE: u8 = 2;
 pub const REJECTION_EXCEEDS_PER_TX_LIMIT: u8 = 3;
 pub const REJECTION_EXCEEDS_DAILY_LIMIT: u8 = 4;
 pub const REJECTION_PROTOCOL_NOT_ALLOWED: u8 = 5;
+pub const REJECTION_EXCEEDS_TX_LIMIT: u8 = 6;
+pub const REJECTION_EXCEEDS_SLIPPAGE_LIMIT: u8 = 7;
+pub const REJECTION_INSUFFICIENT_VAULT_BALANCE: u8 = 8;

--- a/programs/solana-guard/src/constants.rs
+++ b/programs/solana-guard/src/constants.rs
@@ -8,3 +8,10 @@ pub const NONCE_SEED: &[u8] = b"nonce";
 
 /// Time constants
 pub const SECONDS_PER_DAY: i64 = 86_400;
+
+/// Rejection reason codes emitted in TransactionRejected events
+pub const REJECTION_AGENT_NOT_ACTIVE: u8 = 1;
+pub const REJECTION_POLICY_NOT_ACTIVE: u8 = 2;
+pub const REJECTION_EXCEEDS_PER_TX_LIMIT: u8 = 3;
+pub const REJECTION_EXCEEDS_DAILY_LIMIT: u8 = 4;
+pub const REJECTION_PROTOCOL_NOT_ALLOWED: u8 = 5;

--- a/programs/solana-guard/src/error.rs
+++ b/programs/solana-guard/src/error.rs
@@ -14,8 +14,17 @@ pub enum SolanaGuardError {
     #[msg("Transaction would exceed daily spending limit")]
     ExceedsDailyLimit,
 
+    #[msg("Transaction would exceed the daily transaction count limit")]
+    ExceedsTxLimit,
+
     #[msg("Target protocol is not in the allowed list")]
     ProtocolNotAllowed,
+
+    #[msg("Observed slippage exceeds the configured slippage limit")]
+    ExceedsSlippageLimit,
+
+    #[msg("Vault balance is insufficient for this transfer")]
+    InsufficientVaultBalance,
 
     #[msg("Only the owner can perform this action")]
     UnauthorizedOwner,
@@ -34,4 +43,7 @@ pub enum SolanaGuardError {
 
     #[msg("Daily limit must be greater than or equal to per-transaction limit")]
     InvalidDailyLimit,
+
+    #[msg("Daily transaction limit must be greater than zero")]
+    InvalidTxLimit,
 }

--- a/programs/solana-guard/src/instructions.rs
+++ b/programs/solana-guard/src/instructions.rs
@@ -1,12 +1,18 @@
+#![allow(ambiguous_glob_reexports)]
+
+pub mod fund_vault;
 pub mod register_agent;
 pub mod set_policy;
-pub mod validate_and_execute;
 pub mod toggle_agent;
 pub mod update_policy;
+pub mod validate_and_execute;
+pub mod withdraw_vault;
 
 // Re-export everything — Anchor's #[program] macro needs full crate-level access
+pub use fund_vault::*;
 pub use register_agent::*;
 pub use set_policy::*;
-pub use validate_and_execute::*;
 pub use toggle_agent::*;
 pub use update_policy::*;
+pub use validate_and_execute::*;
+pub use withdraw_vault::*;

--- a/programs/solana-guard/src/instructions/fund_vault.rs
+++ b/programs/solana-guard/src/instructions/fund_vault.rs
@@ -1,0 +1,44 @@
+use crate::constants::*;
+use crate::state::*;
+use anchor_lang::prelude::*;
+use anchor_lang::system_program;
+
+pub fn handler(ctx: Context<FundVault>, amount: u64) -> Result<()> {
+    let cpi_accounts = system_program::Transfer {
+        from: ctx.accounts.owner.to_account_info(),
+        to: ctx.accounts.vault.to_account_info(),
+    };
+    let cpi_ctx = CpiContext::new(ctx.accounts.system_program.key(), cpi_accounts);
+    system_program::transfer(cpi_ctx, amount)?;
+
+    msg!(
+        "SolanaGuard: Vault funded for agent {} with {} lamports",
+        ctx.accounts.agent_config.agent,
+        amount
+    );
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct FundVault<'info> {
+    #[account(mut)]
+    pub owner: Signer<'info>,
+
+    #[account(
+        seeds = [AGENT_SEED, owner.key().as_ref(), agent_config.agent.as_ref()],
+        bump = agent_config.bump,
+        has_one = owner,
+    )]
+    pub agent_config: Account<'info, AgentConfig>,
+
+    #[account(
+        mut,
+        seeds = [VAULT_SEED, owner.key().as_ref(), agent_config.agent.as_ref()],
+        bump = vault.bump,
+        has_one = owner,
+    )]
+    pub vault: Account<'info, Vault>,
+
+    pub system_program: Program<'info, System>,
+}

--- a/programs/solana-guard/src/instructions/register_agent.rs
+++ b/programs/solana-guard/src/instructions/register_agent.rs
@@ -1,12 +1,13 @@
-use anchor_lang::prelude::*;
-use crate::state::*;
 use crate::constants::*;
+use crate::state::*;
+use anchor_lang::prelude::*;
 
 /// Registers a new AI agent under the caller's ownership.
 /// Creates an AgentConfig PDA and an AgentNonce tracker.
 pub fn handler(ctx: Context<RegisterAgent>) -> Result<()> {
     let agent_config = &mut ctx.accounts.agent_config;
     let agent_nonce = &mut ctx.accounts.agent_nonce;
+    let vault = &mut ctx.accounts.vault;
     let clock = Clock::get()?;
 
     agent_config.owner = ctx.accounts.owner.key();
@@ -20,10 +21,15 @@ pub fn handler(ctx: Context<RegisterAgent>) -> Result<()> {
     agent_nonce.nonce = 0;
     agent_nonce.bump = ctx.bumps.agent_nonce;
 
+    vault.owner = ctx.accounts.owner.key();
+    vault.agent = ctx.accounts.agent.key();
+    vault.bump = ctx.bumps.vault;
+
     msg!(
-        "SolanaGuard: Agent {} registered by owner {}",
+        "SolanaGuard: Agent {} registered by owner {} with guarded vault {}",
         ctx.accounts.agent.key(),
-        ctx.accounts.owner.key()
+        ctx.accounts.owner.key(),
+        ctx.accounts.vault.key()
     );
 
     Ok(())
@@ -58,6 +64,16 @@ pub struct RegisterAgent<'info> {
         bump,
     )]
     pub agent_nonce: Account<'info, AgentNonce>,
+
+    /// PDA storing funds that can only be spent through guardrail checks
+    #[account(
+        init,
+        payer = owner,
+        space = 8 + Vault::INIT_SPACE,
+        seeds = [VAULT_SEED, owner.key().as_ref(), agent.key().as_ref()],
+        bump,
+    )]
+    pub vault: Account<'info, Vault>,
 
     pub system_program: Program<'info, System>,
 }

--- a/programs/solana-guard/src/instructions/set_policy.rs
+++ b/programs/solana-guard/src/instructions/set_policy.rs
@@ -1,7 +1,7 @@
-use anchor_lang::prelude::*;
-use crate::state::*;
-use crate::error::SolanaGuardError;
 use crate::constants::*;
+use crate::error::SolanaGuardError;
+use crate::state::*;
+use anchor_lang::prelude::*;
 
 /// Sets or updates the risk policy for a registered agent.
 /// Only the owner can set policies for their agents.
@@ -9,11 +9,17 @@ pub fn handler(
     ctx: Context<SetPolicy>,
     max_spend_per_tx: u64,
     daily_limit: u64,
+    max_tx_per_day: u64,
     allowed_protocols: Vec<Pubkey>,
+    slippage_bps: u16,
 ) -> Result<()> {
     // Validate inputs
     require!(max_spend_per_tx > 0, SolanaGuardError::InvalidSpendingLimit);
-    require!(daily_limit >= max_spend_per_tx, SolanaGuardError::InvalidDailyLimit);
+    require!(
+        daily_limit >= max_spend_per_tx,
+        SolanaGuardError::InvalidDailyLimit
+    );
+    require!(max_tx_per_day > 0, SolanaGuardError::InvalidTxLimit);
     require!(
         allowed_protocols.len() <= MAX_ALLOWED_PROTOCOLS,
         SolanaGuardError::TooManyProtocols
@@ -26,17 +32,22 @@ pub fn handler(
     policy.agent = ctx.accounts.agent_config.agent;
     policy.max_spend_per_tx = max_spend_per_tx;
     policy.daily_limit = daily_limit;
+    policy.max_tx_per_day = max_tx_per_day;
     policy.daily_spent = 0;
+    policy.tx_count_today = 0;
     policy.day_start = clock.unix_timestamp;
+    policy.slippage_bps = slippage_bps;
     policy.is_active = true;
     policy.allowed_protocols = allowed_protocols;
     policy.bump = ctx.bumps.policy;
 
     msg!(
-        "SolanaGuard: Policy set for agent {} — max/tx: {} lamports, daily: {} lamports",
+        "SolanaGuard: Policy set for agent {} — max/tx: {} lamports, daily: {} lamports, tx/day: {}, slippage: {} bps",
         policy.agent,
         max_spend_per_tx,
-        daily_limit
+        daily_limit,
+        max_tx_per_day,
+        slippage_bps
     );
 
     Ok(())

--- a/programs/solana-guard/src/instructions/toggle_agent.rs
+++ b/programs/solana-guard/src/instructions/toggle_agent.rs
@@ -1,7 +1,7 @@
-use anchor_lang::prelude::*;
-use crate::state::*;
-use crate::error::SolanaGuardError;
 use crate::constants::*;
+use crate::error::SolanaGuardError;
+use crate::state::*;
+use anchor_lang::prelude::*;
 
 /// Toggles an agent's active status (pause/unpause).
 /// Only the owner can call this.

--- a/programs/solana-guard/src/instructions/update_policy.rs
+++ b/programs/solana-guard/src/instructions/update_policy.rs
@@ -1,7 +1,7 @@
-use anchor_lang::prelude::*;
-use crate::state::*;
-use crate::error::SolanaGuardError;
 use crate::constants::*;
+use crate::error::SolanaGuardError;
+use crate::state::*;
+use anchor_lang::prelude::*;
 
 /// Updates an existing policy's limits and allowed protocols.
 /// Only the owner can update their agent's policy.
@@ -9,12 +9,15 @@ pub fn handler(
     ctx: Context<UpdatePolicy>,
     max_spend_per_tx: Option<u64>,
     daily_limit: Option<u64>,
+    max_tx_per_day: Option<u64>,
     allowed_protocols: Option<Vec<Pubkey>>,
+    slippage_bps: Option<u16>,
     is_active: Option<bool>,
 ) -> Result<()> {
     let policy = &mut ctx.accounts.policy;
     let new_max_spend_per_tx = max_spend_per_tx.unwrap_or(policy.max_spend_per_tx);
     let new_daily_limit = daily_limit.unwrap_or(policy.daily_limit);
+    let new_max_tx_per_day = max_tx_per_day.unwrap_or(policy.max_tx_per_day);
 
     require!(
         new_max_spend_per_tx > 0,
@@ -24,9 +27,11 @@ pub fn handler(
         new_daily_limit >= new_max_spend_per_tx,
         SolanaGuardError::InvalidDailyLimit
     );
+    require!(new_max_tx_per_day > 0, SolanaGuardError::InvalidTxLimit);
 
     policy.max_spend_per_tx = new_max_spend_per_tx;
     policy.daily_limit = new_daily_limit;
+    policy.max_tx_per_day = new_max_tx_per_day;
 
     if let Some(protocols) = allowed_protocols {
         require!(
@@ -36,15 +41,21 @@ pub fn handler(
         policy.allowed_protocols = protocols;
     }
 
+    if let Some(slippage_bps) = slippage_bps {
+        policy.slippage_bps = slippage_bps;
+    }
+
     if let Some(active) = is_active {
         policy.is_active = active;
     }
 
     msg!(
-        "SolanaGuard: Policy updated for agent {} — max/tx: {}, daily: {}, active: {}",
+        "SolanaGuard: Policy updated for agent {} — max/tx: {}, daily: {}, tx/day: {}, slippage: {} bps, active: {}",
         policy.agent,
         policy.max_spend_per_tx,
         policy.daily_limit,
+        policy.max_tx_per_day,
+        policy.slippage_bps,
         policy.is_active
     );
 

--- a/programs/solana-guard/src/instructions/validate_and_execute.rs
+++ b/programs/solana-guard/src/instructions/validate_and_execute.rs
@@ -23,39 +23,91 @@ pub fn handler(
     let tx_log = &mut ctx.accounts.tx_log;
     let agent_nonce = &mut ctx.accounts.agent_nonce;
     let clock = Clock::get()?;
+    let now = clock.unix_timestamp;
 
     // ---- Check 1: Agent must be active ----
-    require!(agent_config.is_active, SolanaGuardError::AgentNotActive);
+    if !agent_config.is_active {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            policy.daily_spent,
+            now,
+            REJECTION_AGENT_NOT_ACTIVE,
+        );
+        return err!(SolanaGuardError::AgentNotActive);
+    }
 
     // ---- Check 2: Policy must be active ----
-    require!(policy.is_active, SolanaGuardError::PolicyNotActive);
+    if !policy.is_active {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            policy.daily_spent,
+            now,
+            REJECTION_POLICY_NOT_ACTIVE,
+        );
+        return err!(SolanaGuardError::PolicyNotActive);
+    }
 
     // ---- Check 3: Per-transaction limit ----
-    require!(
-        amount <= policy.max_spend_per_tx,
-        SolanaGuardError::ExceedsPerTxLimit
-    );
+    if amount > policy.max_spend_per_tx {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            policy.daily_spent,
+            now,
+            REJECTION_EXCEEDS_PER_TX_LIMIT,
+        );
+        return err!(SolanaGuardError::ExceedsPerTxLimit);
+    }
 
     // ---- Check 4: Daily limit (with 24h reset) ----
-    let now = clock.unix_timestamp;
-    if now - policy.day_start >= SECONDS_PER_DAY {
+    let should_reset_day = now - policy.day_start >= SECONDS_PER_DAY;
+    let current_daily_spent = if should_reset_day {
+        0
+    } else {
+        policy.daily_spent
+    };
+
+    if current_daily_spent.checked_add(amount).unwrap_or(u64::MAX) > policy.daily_limit {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            current_daily_spent,
+            now,
+            REJECTION_EXCEEDS_DAILY_LIMIT,
+        );
+        return err!(SolanaGuardError::ExceedsDailyLimit);
+    }
+
+    // ---- Check 5: Protocol allowlist ----
+    if !policy.allowed_protocols.contains(&target_protocol) {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            current_daily_spent,
+            now,
+            REJECTION_PROTOCOL_NOT_ALLOWED,
+        );
+        return err!(SolanaGuardError::ProtocolNotAllowed);
+    }
+
+    // ---- All checks passed — update state ----
+    if should_reset_day {
         // Reset the daily counter — new day
         policy.daily_spent = 0;
         policy.day_start = now;
     }
-
-    require!(
-        policy.daily_spent.checked_add(amount).unwrap_or(u64::MAX) <= policy.daily_limit,
-        SolanaGuardError::ExceedsDailyLimit
-    );
-
-    // ---- Check 5: Protocol allowlist ----
-    require!(
-        policy.allowed_protocols.contains(&target_protocol),
-        SolanaGuardError::ProtocolNotAllowed
-    );
-
-    // ---- All checks passed — update state ----
     policy.daily_spent = policy.daily_spent.checked_add(amount).unwrap();
 
     // Write transaction log
@@ -81,6 +133,27 @@ pub fn handler(
     );
 
     Ok(())
+}
+
+fn emit_rejection(
+    agent_config: &AgentConfig,
+    policy: &Policy,
+    amount: u64,
+    target_protocol: Pubkey,
+    daily_spent: u64,
+    rejected_at: i64,
+    reason_code: u8,
+) {
+    emit!(TransactionRejected {
+        agent: agent_config.agent,
+        owner: agent_config.owner,
+        amount,
+        target_protocol,
+        daily_spent,
+        daily_limit: policy.daily_limit,
+        rejected_at,
+        reason_code,
+    });
 }
 
 #[derive(Accounts)]

--- a/programs/solana-guard/src/instructions/validate_and_execute.rs
+++ b/programs/solana-guard/src/instructions/validate_and_execute.rs
@@ -1,10 +1,10 @@
-use anchor_lang::prelude::*;
-use crate::state::*;
-use crate::error::SolanaGuardError;
 use crate::constants::*;
+use crate::error::SolanaGuardError;
+use crate::state::*;
+use anchor_lang::prelude::*;
 
 /// Validates a transaction against the agent's policy, then executes it.
-/// This is the core guardrail enforcement — every agent transaction must 
+/// This is the core guardrail enforcement — every agent transaction must
 /// pass through this instruction.
 ///
 /// Checks enforced:
@@ -17,54 +17,71 @@ pub fn handler(
     ctx: Context<ValidateAndExecute>,
     amount: u64,
     target_protocol: Pubkey,
+    observed_slippage_bps: u16,
 ) -> Result<()> {
     let agent_config = &ctx.accounts.agent_config;
     let policy = &mut ctx.accounts.policy;
     let tx_log = &mut ctx.accounts.tx_log;
     let agent_nonce = &mut ctx.accounts.agent_nonce;
+    let vault = &ctx.accounts.vault;
     let clock = Clock::get()?;
     let now = clock.unix_timestamp;
 
     // ---- Check 1: Agent must be active ----
     if !agent_config.is_active {
-        emit_rejection(
+        record_rejection(
+            tx_log,
+            agent_nonce,
             agent_config,
             policy,
             amount,
             target_protocol,
+            observed_slippage_bps,
             policy.daily_spent,
+            policy.tx_count_today,
             now,
             REJECTION_AGENT_NOT_ACTIVE,
+            ctx.bumps.tx_log,
         );
-        return err!(SolanaGuardError::AgentNotActive);
+        return Ok(());
     }
 
     // ---- Check 2: Policy must be active ----
     if !policy.is_active {
-        emit_rejection(
+        record_rejection(
+            tx_log,
+            agent_nonce,
             agent_config,
             policy,
             amount,
             target_protocol,
+            observed_slippage_bps,
             policy.daily_spent,
+            policy.tx_count_today,
             now,
             REJECTION_POLICY_NOT_ACTIVE,
+            ctx.bumps.tx_log,
         );
-        return err!(SolanaGuardError::PolicyNotActive);
+        return Ok(());
     }
 
     // ---- Check 3: Per-transaction limit ----
     if amount > policy.max_spend_per_tx {
-        emit_rejection(
+        record_rejection(
+            tx_log,
+            agent_nonce,
             agent_config,
             policy,
             amount,
             target_protocol,
+            observed_slippage_bps,
             policy.daily_spent,
+            policy.tx_count_today,
             now,
             REJECTION_EXCEEDS_PER_TX_LIMIT,
+            ctx.bumps.tx_log,
         );
-        return err!(SolanaGuardError::ExceedsPerTxLimit);
+        return Ok(());
     }
 
     // ---- Check 4: Daily limit (with 24h reset) ----
@@ -74,49 +91,131 @@ pub fn handler(
     } else {
         policy.daily_spent
     };
+    let current_tx_count = if should_reset_day {
+        0
+    } else {
+        policy.tx_count_today
+    };
 
     if current_daily_spent.checked_add(amount).unwrap_or(u64::MAX) > policy.daily_limit {
-        emit_rejection(
+        record_rejection(
+            tx_log,
+            agent_nonce,
             agent_config,
             policy,
             amount,
             target_protocol,
+            observed_slippage_bps,
             current_daily_spent,
+            current_tx_count,
             now,
             REJECTION_EXCEEDS_DAILY_LIMIT,
+            ctx.bumps.tx_log,
         );
-        return err!(SolanaGuardError::ExceedsDailyLimit);
+        return Ok(());
     }
 
-    // ---- Check 5: Protocol allowlist ----
-    if !policy.allowed_protocols.contains(&target_protocol) {
-        emit_rejection(
+    // ---- Check 5: Daily transaction count ----
+    if current_tx_count.checked_add(1).unwrap_or(u64::MAX) > policy.max_tx_per_day {
+        record_rejection(
+            tx_log,
+            agent_nonce,
             agent_config,
             policy,
             amount,
             target_protocol,
+            observed_slippage_bps,
             current_daily_spent,
+            current_tx_count,
             now,
-            REJECTION_PROTOCOL_NOT_ALLOWED,
+            REJECTION_EXCEEDS_TX_LIMIT,
+            ctx.bumps.tx_log,
         );
-        return err!(SolanaGuardError::ProtocolNotAllowed);
+        return Ok(());
     }
 
-    // ---- All checks passed — update state ----
+    // ---- Check 6: Protocol allowlist ----
+    if !policy.allowed_protocols.contains(&target_protocol) {
+        record_rejection(
+            tx_log,
+            agent_nonce,
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            observed_slippage_bps,
+            current_daily_spent,
+            current_tx_count,
+            now,
+            REJECTION_PROTOCOL_NOT_ALLOWED,
+            ctx.bumps.tx_log,
+        );
+        return Ok(());
+    }
+
+    // ---- Check 7: Slippage guard ----
+    if observed_slippage_bps > policy.slippage_bps {
+        record_rejection(
+            tx_log,
+            agent_nonce,
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            observed_slippage_bps,
+            current_daily_spent,
+            current_tx_count,
+            now,
+            REJECTION_EXCEEDS_SLIPPAGE_LIMIT,
+            ctx.bumps.tx_log,
+        );
+        return Ok(());
+    }
+
+    // ---- Check 8: Vault must hold the guarded funds ----
+    if vault.to_account_info().lamports() < amount {
+        record_rejection(
+            tx_log,
+            agent_nonce,
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            observed_slippage_bps,
+            current_daily_spent,
+            current_tx_count,
+            now,
+            REJECTION_INSUFFICIENT_VAULT_BALANCE,
+            ctx.bumps.tx_log,
+        );
+        return Ok(());
+    }
+
+    // ---- All checks passed — execute the guarded transfer ----
+    let vault_info = vault.to_account_info();
+    let recipient_info = ctx.accounts.recipient.to_account_info();
+    **vault_info.try_borrow_mut_lamports()? -= amount;
+    **recipient_info.try_borrow_mut_lamports()? += amount;
+
+    // ---- Update state after the transfer succeeds ----
     if should_reset_day {
         // Reset the daily counter — new day
         policy.daily_spent = 0;
+        policy.tx_count_today = 0;
         policy.day_start = now;
     }
     policy.daily_spent = policy.daily_spent.checked_add(amount).unwrap();
+    policy.tx_count_today = policy.tx_count_today.checked_add(1).unwrap();
 
     // Write transaction log
     tx_log.agent = agent_config.agent;
     tx_log.owner = agent_config.owner;
     tx_log.amount = amount;
+    tx_log.slippage_bps = observed_slippage_bps;
     tx_log.target_protocol = target_protocol;
     tx_log.executed_at = now;
     tx_log.was_approved = true;
+    tx_log.reason_code = REJECTION_NONE;
     tx_log.nonce = agent_nonce.nonce;
     tx_log.bump = ctx.bumps.tx_log;
 
@@ -124,39 +223,73 @@ pub fn handler(
     agent_nonce.nonce = agent_nonce.nonce.checked_add(1).unwrap();
 
     msg!(
-        "SolanaGuard: ✅ APPROVED — Agent {} spent {} lamports on protocol {}. Daily total: {}/{}",
+        "SolanaGuard: ✅ APPROVED — Agent {} spent {} lamports from vault {} to {}. Daily total: {}/{}, tx count: {}/{}, slippage: {}/{} bps",
         agent_config.agent,
         amount,
-        target_protocol,
+        vault.key(),
+        ctx.accounts.recipient.key(),
         policy.daily_spent,
-        policy.daily_limit
+        policy.daily_limit,
+        policy.tx_count_today,
+        policy.max_tx_per_day,
+        observed_slippage_bps,
+        policy.slippage_bps
     );
 
     Ok(())
 }
 
-fn emit_rejection(
+fn record_rejection(
+    tx_log: &mut Account<TransactionLog>,
+    agent_nonce: &mut Account<AgentNonce>,
     agent_config: &AgentConfig,
     policy: &Policy,
     amount: u64,
     target_protocol: Pubkey,
+    slippage_bps: u16,
     daily_spent: u64,
+    tx_count_today: u64,
     rejected_at: i64,
     reason_code: u8,
+    tx_log_bump: u8,
 ) {
+    tx_log.agent = agent_config.agent;
+    tx_log.owner = agent_config.owner;
+    tx_log.amount = amount;
+    tx_log.slippage_bps = slippage_bps;
+    tx_log.target_protocol = target_protocol;
+    tx_log.executed_at = rejected_at;
+    tx_log.was_approved = false;
+    tx_log.reason_code = reason_code;
+    tx_log.nonce = agent_nonce.nonce;
+    tx_log.bump = tx_log_bump;
+
+    agent_nonce.nonce = agent_nonce.nonce.checked_add(1).unwrap();
+
     emit!(TransactionRejected {
         agent: agent_config.agent,
         owner: agent_config.owner,
         amount,
+        slippage_bps,
         target_protocol,
         daily_spent,
+        tx_count_today,
         daily_limit: policy.daily_limit,
         rejected_at,
         reason_code,
     });
+
+    msg!(
+        "SolanaGuard: REJECTED — Agent {} attempted {} lamports to {} with reason code {}",
+        agent_config.agent,
+        amount,
+        target_protocol,
+        reason_code
+    );
 }
 
 #[derive(Accounts)]
+#[instruction(amount: u64, target_protocol: Pubkey, observed_slippage_bps: u16)]
 pub struct ValidateAndExecute<'info> {
     /// The agent executing the transaction (must be the registered agent)
     #[account(mut)]
@@ -181,6 +314,20 @@ pub struct ValidateAndExecute<'info> {
         bump = policy.bump,
     )]
     pub policy: Account<'info, Policy>,
+
+    /// Program-controlled vault holding the funds subject to guardrails
+    #[account(
+        mut,
+        seeds = [VAULT_SEED, owner.key().as_ref(), agent.key().as_ref()],
+        bump = vault.bump,
+        has_one = owner @ SolanaGuardError::UnauthorizedOwner,
+        has_one = agent @ SolanaGuardError::UnauthorizedAgent,
+    )]
+    pub vault: Account<'info, Vault>,
+
+    /// CHECK: Recipient of the guarded transfer. The key must match the allowlisted target.
+    #[account(mut, address = target_protocol)]
+    pub recipient: UncheckedAccount<'info>,
 
     /// Transaction log entry (created per transaction)
     #[account(

--- a/programs/solana-guard/src/instructions/withdraw_vault.rs
+++ b/programs/solana-guard/src/instructions/withdraw_vault.rs
@@ -1,0 +1,47 @@
+use crate::constants::*;
+use crate::error::SolanaGuardError;
+use crate::state::*;
+use anchor_lang::prelude::*;
+
+pub fn handler(ctx: Context<WithdrawVault>, amount: u64) -> Result<()> {
+    let vault_info = ctx.accounts.vault.to_account_info();
+    let owner_info = ctx.accounts.owner.to_account_info();
+
+    require!(
+        vault_info.lamports() >= amount,
+        SolanaGuardError::InsufficientVaultBalance
+    );
+
+    **vault_info.try_borrow_mut_lamports()? -= amount;
+    **owner_info.try_borrow_mut_lamports()? += amount;
+
+    msg!(
+        "SolanaGuard: Owner {} withdrew {} lamports from vault for agent {}",
+        ctx.accounts.owner.key(),
+        amount,
+        ctx.accounts.agent_config.agent
+    );
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct WithdrawVault<'info> {
+    #[account(mut)]
+    pub owner: Signer<'info>,
+
+    #[account(
+        seeds = [AGENT_SEED, owner.key().as_ref(), agent_config.agent.as_ref()],
+        bump = agent_config.bump,
+        has_one = owner,
+    )]
+    pub agent_config: Account<'info, AgentConfig>,
+
+    #[account(
+        mut,
+        seeds = [VAULT_SEED, owner.key().as_ref(), agent_config.agent.as_ref()],
+        bump = vault.bump,
+        has_one = owner,
+    )]
+    pub vault: Account<'info, Vault>,
+}

--- a/programs/solana-guard/src/lib.rs
+++ b/programs/solana-guard/src/lib.rs
@@ -16,9 +16,14 @@ pub mod solana_guard {
     use super::*;
 
     /// Register a new AI agent under the caller's ownership.
-    /// Creates an AgentConfig PDA bound to the owner+agent pair.
+    /// Creates an AgentConfig PDA bound to the owner+agent pair and a vault PDA.
     pub fn register_agent(ctx: Context<RegisterAgent>) -> Result<()> {
         instructions::register_agent::handler(ctx)
+    }
+
+    /// Fund the program-controlled vault for a registered agent.
+    pub fn fund_vault(ctx: Context<FundVault>, amount: u64) -> Result<()> {
+        instructions::fund_vault::handler(ctx, amount)
     }
 
     /// Set the risk policy for a registered agent.
@@ -27,9 +32,18 @@ pub mod solana_guard {
         ctx: Context<SetPolicy>,
         max_spend_per_tx: u64,
         daily_limit: u64,
+        max_tx_per_day: u64,
         allowed_protocols: Vec<Pubkey>,
+        slippage_bps: u16,
     ) -> Result<()> {
-        instructions::set_policy::handler(ctx, max_spend_per_tx, daily_limit, allowed_protocols)
+        instructions::set_policy::handler(
+            ctx,
+            max_spend_per_tx,
+            daily_limit,
+            max_tx_per_day,
+            allowed_protocols,
+            slippage_bps,
+        )
     }
 
     /// Validate a transaction against the agent's policy and log it.
@@ -38,8 +52,14 @@ pub mod solana_guard {
         ctx: Context<ValidateAndExecute>,
         amount: u64,
         target_protocol: Pubkey,
+        observed_slippage_bps: u16,
     ) -> Result<()> {
-        instructions::validate_and_execute::handler(ctx, amount, target_protocol)
+        instructions::validate_and_execute::handler(
+            ctx,
+            amount,
+            target_protocol,
+            observed_slippage_bps,
+        )
     }
 
     /// Toggle agent active status (emergency kill switch).
@@ -48,20 +68,29 @@ pub mod solana_guard {
         instructions::toggle_agent::handler(ctx, is_active)
     }
 
+    /// Withdraw SOL from the vault back to the owner.
+    pub fn withdraw_vault(ctx: Context<WithdrawVault>, amount: u64) -> Result<()> {
+        instructions::withdraw_vault::handler(ctx, amount)
+    }
+
     /// Update an existing policy's parameters.
     /// Supports partial updates — only provided fields are changed.
     pub fn update_policy(
         ctx: Context<UpdatePolicy>,
         max_spend_per_tx: Option<u64>,
         daily_limit: Option<u64>,
+        max_tx_per_day: Option<u64>,
         allowed_protocols: Option<Vec<Pubkey>>,
+        slippage_bps: Option<u16>,
         is_active: Option<bool>,
     ) -> Result<()> {
         instructions::update_policy::handler(
             ctx,
             max_spend_per_tx,
             daily_limit,
+            max_tx_per_day,
             allowed_protocols,
+            slippage_bps,
             is_active,
         )
     }

--- a/programs/solana-guard/src/state.rs
+++ b/programs/solana-guard/src/state.rs
@@ -31,10 +31,16 @@ pub struct Policy {
     pub max_spend_per_tx: u64,
     /// Maximum SOL (in lamports) the agent can spend per day
     pub daily_limit: u64,
+    /// Maximum number of approved transactions per day
+    pub max_tx_per_day: u64,
     /// Running total of SOL spent in the current day
     pub daily_spent: u64,
+    /// Number of approved transactions in the current day
+    pub tx_count_today: u64,
     /// Unix timestamp of the current spending day (resets every 24h)
     pub day_start: i64,
+    /// Maximum permitted slippage in basis points
+    pub slippage_bps: u16,
     /// Whether the policy is active (owner can pause)
     pub is_active: bool,
     /// List of program IDs the agent is allowed to interact with
@@ -54,12 +60,16 @@ pub struct TransactionLog {
     pub owner: Pubkey,
     /// Amount in lamports
     pub amount: u64,
+    /// Slippage reported for this attempted action, in basis points
+    pub slippage_bps: u16,
     /// The target program the agent interacted with
     pub target_protocol: Pubkey,
     /// Timestamp of execution
     pub executed_at: i64,
     /// Whether the transaction was approved or rejected
     pub was_approved: bool,
+    /// Machine-readable reason code. Zero means approved.
+    pub reason_code: u8,
     /// Sequential nonce for uniqueness
     pub nonce: u64,
     /// Bump seed
@@ -77,10 +87,14 @@ pub struct TransactionRejected {
     pub owner: Pubkey,
     /// Requested amount in lamports
     pub amount: u64,
+    /// Slippage reported for the attempted action, in basis points
+    pub slippage_bps: u16,
     /// The target program the agent attempted to interact with
     pub target_protocol: Pubkey,
     /// Running daily spend used for the validation
     pub daily_spent: u64,
+    /// Running transaction count used for the validation
+    pub tx_count_today: u64,
     /// Configured daily limit
     pub daily_limit: u64,
     /// Timestamp of rejection
@@ -96,5 +110,17 @@ pub struct AgentNonce {
     pub owner: Pubkey,
     pub agent: Pubkey,
     pub nonce: u64,
+    pub bump: u8,
+}
+
+/// Program-controlled SOL vault used for deterministic guarded execution
+#[account]
+#[derive(InitSpace)]
+pub struct Vault {
+    /// Owner that can fund or withdraw this vault
+    pub owner: Pubkey,
+    /// Agent authorized to spend through guardrails
+    pub agent: Pubkey,
+    /// PDA bump
     pub bump: u8,
 }

--- a/programs/solana-guard/src/state.rs
+++ b/programs/solana-guard/src/state.rs
@@ -66,6 +66,29 @@ pub struct TransactionLog {
     pub bump: u8,
 }
 
+/// Event emitted when a transaction attempt is rejected.
+/// Failed instructions cannot persist TransactionLog accounts, so rejected
+/// attempts are exposed through transaction logs instead.
+#[event]
+pub struct TransactionRejected {
+    /// The agent that attempted this transaction
+    pub agent: Pubkey,
+    /// The owner of the agent
+    pub owner: Pubkey,
+    /// Requested amount in lamports
+    pub amount: u64,
+    /// The target program the agent attempted to interact with
+    pub target_protocol: Pubkey,
+    /// Running daily spend used for the validation
+    pub daily_spent: u64,
+    /// Configured daily limit
+    pub daily_limit: u64,
+    /// Timestamp of rejection
+    pub rejected_at: i64,
+    /// Machine-readable reason code. See constants.rs.
+    pub reason_code: u8,
+}
+
 /// Global nonce tracker per agent for transaction log indexing
 #[account]
 #[derive(InitSpace)]

--- a/programs/solana-guard/tests/test_initialize.rs
+++ b/programs/solana-guard/tests/test_initialize.rs
@@ -1,40 +1,157 @@
 use {
     anchor_lang::{
-        solana_program::instruction::Instruction,
-        solana_program::pubkey::Pubkey,
-        InstructionData, ToAccountMetas,
+        solana_program::instruction::Instruction, solana_program::pubkey::Pubkey,
+        AccountDeserialize, InstructionData, ToAccountMetas,
     },
     litesvm::LiteSVM,
+    solana_keypair::Keypair,
     solana_message::{Message, VersionedMessage},
     solana_signer::Signer,
-    solana_keypair::Keypair,
     solana_transaction::versioned::VersionedTransaction,
     std::{fs, io::ErrorKind, path::PathBuf},
 };
 
+struct TestContext {
+    svm: LiteSVM,
+    owner: Keypair,
+    agent: Keypair,
+    recipient: Keypair,
+    allowed_protocol: Pubkey,
+    agent_config_pda: Pubkey,
+    agent_nonce_pda: Pubkey,
+    policy_pda: Pubkey,
+    vault_pda: Pubkey,
+}
+
 #[test]
 fn test_register_agent() {
-    let program_id = solana_guard::id();
-    let owner = Keypair::new();
-    let agent = Keypair::new();
-    let mut svm = LiteSVM::new();
+    let Some(mut ctx) = setup() else {
+        return;
+    };
+
+    register_agent(&mut ctx);
+
+    let agent_config_account = ctx
+        .svm
+        .get_account(&ctx.agent_config_pda)
+        .expect("agent config should exist");
+    let agent_config =
+        solana_guard::AgentConfig::try_deserialize(&mut agent_config_account.data.as_slice())
+            .expect("agent config should deserialize");
+
+    assert_eq!(agent_config.owner, ctx.owner.pubkey());
+    assert_eq!(agent_config.agent, ctx.agent.pubkey());
+    assert!(agent_config.is_active);
+}
+
+#[test]
+fn test_validate_and_execute_enforces_daily_tx_limit_and_slippage() {
+    let Some(mut ctx) = setup() else {
+        return;
+    };
+
+    register_agent(&mut ctx);
+    set_policy(&mut ctx, 1_000_000, 2_000_000, 1, 50);
+    fund_vault(&mut ctx, 1_000_000);
+    let allowed_protocol = ctx.allowed_protocol;
+    let recipient_before = balance(&ctx, &ctx.recipient.pubkey());
+    let vault_before = balance(&ctx, &ctx.vault_pda);
+
+    let first_attempt = validate_and_execute(&mut ctx, 500_000, allowed_protocol, 25);
+    assert!(first_attempt.is_ok(), "first guarded tx should pass");
+    let approved_log = fetch_tx_log(&ctx, 0);
+
+    let policy_after_success = fetch_policy(&ctx);
+    assert_eq!(policy_after_success.daily_spent, 500_000);
+    assert_eq!(policy_after_success.tx_count_today, 1);
+    assert_eq!(policy_after_success.max_tx_per_day, 1);
+    assert_eq!(policy_after_success.slippage_bps, 50);
+    assert_eq!(
+        balance(&ctx, &ctx.recipient.pubkey()),
+        recipient_before + 500_000
+    );
+    assert_eq!(balance(&ctx, &ctx.vault_pda), vault_before - 500_000);
+    assert!(approved_log.was_approved);
+    assert_eq!(approved_log.reason_code, solana_guard::REJECTION_NONE);
+
+    let second_attempt = validate_and_execute(&mut ctx, 100_000, allowed_protocol, 25);
+    assert!(second_attempt.is_ok(), "rejected tx should still be logged");
+    let rejected_tx_limit_log = fetch_tx_log(&ctx, 1);
+
+    let policy_after_failures = fetch_policy(&ctx);
+    assert_eq!(policy_after_failures.daily_spent, 500_000);
+    assert_eq!(policy_after_failures.tx_count_today, 1);
+    assert_eq!(
+        balance(&ctx, &ctx.recipient.pubkey()),
+        recipient_before + 500_000
+    );
+    assert_eq!(balance(&ctx, &ctx.vault_pda), vault_before - 500_000);
+    assert!(!rejected_tx_limit_log.was_approved);
+    assert_eq!(
+        rejected_tx_limit_log.reason_code,
+        solana_guard::REJECTION_EXCEEDS_TX_LIMIT
+    );
+}
+
+#[test]
+fn test_validate_and_execute_logs_rejected_slippage_attempts() {
+    let Some(mut ctx) = setup() else {
+        return;
+    };
+
+    register_agent(&mut ctx);
+    set_policy(&mut ctx, 1_000_000, 2_000_000, 3, 50);
+    fund_vault(&mut ctx, 1_000_000);
+    let allowed_protocol = ctx.allowed_protocol;
+    let recipient_before = balance(&ctx, &ctx.recipient.pubkey());
+    let vault_before = balance(&ctx, &ctx.vault_pda);
+
+    let rejected_attempt = validate_and_execute(&mut ctx, 250_000, allowed_protocol, 75);
+    assert!(
+        rejected_attempt.is_ok(),
+        "slippage rejection should be logged"
+    );
+
+    let rejected_log = fetch_tx_log(&ctx, 0);
+    let policy_after = fetch_policy(&ctx);
+
+    assert!(!rejected_log.was_approved);
+    assert_eq!(
+        rejected_log.reason_code,
+        solana_guard::REJECTION_EXCEEDS_SLIPPAGE_LIMIT
+    );
+    assert_eq!(policy_after.daily_spent, 0);
+    assert_eq!(policy_after.tx_count_today, 0);
+    assert_eq!(balance(&ctx, &ctx.recipient.pubkey()), recipient_before);
+    assert_eq!(balance(&ctx, &ctx.vault_pda), vault_before);
+}
+
+fn setup() -> Option<TestContext> {
     let program_path =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/deploy/solana_guard.so");
     let bytes = match fs::read(&program_path) {
         Ok(bytes) => bytes,
         Err(err) if err.kind() == ErrorKind::NotFound => {
             eprintln!(
-                "Skipping LiteSVM register_agent test because {} does not exist. Run `anchor build` to generate it.",
+                "Skipping LiteSVM tests because {} does not exist. Run `anchor build` to generate it.",
                 program_path.display()
             );
-            return;
+            return None;
         }
         Err(err) => panic!("failed to read {}: {err}", program_path.display()),
     };
+
+    let program_id = solana_guard::id();
+    let owner = Keypair::new();
+    let agent = Keypair::new();
+    let recipient = Keypair::new();
+    let allowed_protocol = recipient.pubkey();
+    let mut svm = LiteSVM::new();
     svm.add_program(program_id, &bytes).unwrap();
     svm.airdrop(&owner.pubkey(), 10_000_000_000).unwrap();
+    svm.airdrop(&agent.pubkey(), 10_000_000_000).unwrap();
+    svm.airdrop(&recipient.pubkey(), 1_000_000).unwrap();
 
-    // Derive PDAs
     let (agent_config_pda, _) = Pubkey::find_program_address(
         &[b"agent", owner.pubkey().as_ref(), agent.pubkey().as_ref()],
         &program_id,
@@ -43,24 +160,203 @@ fn test_register_agent() {
         &[b"nonce", owner.pubkey().as_ref(), agent.pubkey().as_ref()],
         &program_id,
     );
+    let (policy_pda, _) = Pubkey::find_program_address(
+        &[b"policy", owner.pubkey().as_ref(), agent.pubkey().as_ref()],
+        &program_id,
+    );
+    let (vault_pda, _) = Pubkey::find_program_address(
+        &[b"vault", owner.pubkey().as_ref(), agent.pubkey().as_ref()],
+        &program_id,
+    );
 
+    Some(TestContext {
+        svm,
+        owner,
+        agent,
+        recipient,
+        allowed_protocol,
+        agent_config_pda,
+        agent_nonce_pda,
+        policy_pda,
+        vault_pda,
+    })
+}
+
+fn register_agent(ctx: &mut TestContext) {
     let instruction = Instruction::new_with_bytes(
-        program_id,
+        solana_guard::id(),
         &solana_guard::instruction::RegisterAgent {}.data(),
         solana_guard::accounts::RegisterAgent {
-            owner: owner.pubkey(),
-            agent: agent.pubkey(),
-            agent_config: agent_config_pda,
-            agent_nonce: agent_nonce_pda,
+            owner: ctx.owner.pubkey(),
+            agent: ctx.agent.pubkey(),
+            agent_config: ctx.agent_config_pda,
+            agent_nonce: ctx.agent_nonce_pda,
+            vault: ctx.vault_pda,
             system_program: anchor_lang::system_program::ID,
         }
         .to_account_metas(None),
     );
 
-    let blockhash = svm.latest_blockhash();
-    let msg = Message::new_with_blockhash(&[instruction], Some(&owner.pubkey()), &blockhash);
-    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), &[owner]).unwrap();
+    let result = send_tx(
+        &mut ctx.svm,
+        &[instruction],
+        &ctx.owner.pubkey(),
+        &[&ctx.owner],
+    );
+    assert!(result.is_ok(), "register_agent failed: {:?}", result.err());
+}
 
-    let res = svm.send_transaction(tx);
-    assert!(res.is_ok(), "register_agent failed: {:?}", res.err());
+fn fund_vault(ctx: &mut TestContext, amount: u64) {
+    let instruction = Instruction::new_with_bytes(
+        solana_guard::id(),
+        &solana_guard::instruction::FundVault { amount }.data(),
+        solana_guard::accounts::FundVault {
+            owner: ctx.owner.pubkey(),
+            agent_config: ctx.agent_config_pda,
+            vault: ctx.vault_pda,
+            system_program: anchor_lang::system_program::ID,
+        }
+        .to_account_metas(None),
+    );
+
+    let result = send_tx(
+        &mut ctx.svm,
+        &[instruction],
+        &ctx.owner.pubkey(),
+        &[&ctx.owner],
+    );
+    assert!(result.is_ok(), "fund_vault failed: {:?}", result.err());
+}
+
+fn set_policy(
+    ctx: &mut TestContext,
+    max_spend_per_tx: u64,
+    daily_limit: u64,
+    max_tx_per_day: u64,
+    slippage_bps: u16,
+) {
+    let instruction = Instruction::new_with_bytes(
+        solana_guard::id(),
+        &solana_guard::instruction::SetPolicy {
+            max_spend_per_tx,
+            daily_limit,
+            max_tx_per_day,
+            allowed_protocols: vec![ctx.allowed_protocol],
+            slippage_bps,
+        }
+        .data(),
+        solana_guard::accounts::SetPolicy {
+            owner: ctx.owner.pubkey(),
+            agent_config: ctx.agent_config_pda,
+            policy: ctx.policy_pda,
+            system_program: anchor_lang::system_program::ID,
+        }
+        .to_account_metas(None),
+    );
+
+    let result = send_tx(
+        &mut ctx.svm,
+        &[instruction],
+        &ctx.owner.pubkey(),
+        &[&ctx.owner],
+    );
+    assert!(result.is_ok(), "set_policy failed: {:?}", result.err());
+}
+
+fn validate_and_execute(
+    ctx: &mut TestContext,
+    amount: u64,
+    target_protocol: Pubkey,
+    observed_slippage_bps: u16,
+) -> Result<(), String> {
+    let nonce = fetch_nonce(ctx);
+    let (tx_log_pda, _) = Pubkey::find_program_address(
+        &[b"tx_log", ctx.agent.pubkey().as_ref(), &nonce.to_le_bytes()],
+        &solana_guard::id(),
+    );
+
+    let instruction = Instruction::new_with_bytes(
+        solana_guard::id(),
+        &solana_guard::instruction::ValidateAndExecute {
+            amount,
+            target_protocol,
+            observed_slippage_bps,
+        }
+        .data(),
+        solana_guard::accounts::ValidateAndExecute {
+            agent: ctx.agent.pubkey(),
+            owner: ctx.owner.pubkey(),
+            agent_config: ctx.agent_config_pda,
+            policy: ctx.policy_pda,
+            vault: ctx.vault_pda,
+            recipient: ctx.recipient.pubkey(),
+            tx_log: tx_log_pda,
+            agent_nonce: ctx.agent_nonce_pda,
+            system_program: anchor_lang::system_program::ID,
+        }
+        .to_account_metas(None),
+    );
+
+    send_tx(
+        &mut ctx.svm,
+        &[instruction],
+        &ctx.agent.pubkey(),
+        &[&ctx.agent],
+    )
+    .map(|_| ())
+}
+
+fn balance(ctx: &TestContext, address: &Pubkey) -> u64 {
+    ctx.svm
+        .get_account(address)
+        .map(|account| account.lamports)
+        .unwrap_or(0)
+}
+
+fn fetch_policy(ctx: &TestContext) -> solana_guard::Policy {
+    let policy_account = ctx
+        .svm
+        .get_account(&ctx.policy_pda)
+        .expect("policy account should exist");
+    solana_guard::Policy::try_deserialize(&mut policy_account.data.as_slice())
+        .expect("policy should deserialize")
+}
+
+fn fetch_nonce(ctx: &TestContext) -> u64 {
+    let nonce_account = ctx
+        .svm
+        .get_account(&ctx.agent_nonce_pda)
+        .expect("agent nonce should exist");
+    let nonce = solana_guard::AgentNonce::try_deserialize(&mut nonce_account.data.as_slice())
+        .expect("nonce should deserialize");
+    nonce.nonce
+}
+
+fn fetch_tx_log(ctx: &TestContext, nonce: u64) -> solana_guard::TransactionLog {
+    let (tx_log_pda, _) = Pubkey::find_program_address(
+        &[b"tx_log", ctx.agent.pubkey().as_ref(), &nonce.to_le_bytes()],
+        &solana_guard::id(),
+    );
+    let tx_log_account = ctx
+        .svm
+        .get_account(&tx_log_pda)
+        .expect("tx log should exist");
+    solana_guard::TransactionLog::try_deserialize(&mut tx_log_account.data.as_slice())
+        .expect("tx log should deserialize")
+}
+
+fn send_tx(
+    svm: &mut LiteSVM,
+    instructions: &[Instruction],
+    payer: &Pubkey,
+    signers: &[&Keypair],
+) -> Result<(), String> {
+    let blockhash = svm.latest_blockhash();
+    let msg = Message::new_with_blockhash(instructions, Some(payer), &blockhash);
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers)
+        .map_err(|err| format!("failed to sign tx: {err}"))?;
+
+    svm.send_transaction(tx)
+        .map(|_| ())
+        .map_err(|err| format!("{:?}", err.err))
 }


### PR DESCRIPTION
## Summary
- add a program-controlled vault for each registered agent
- enforce guarded execution by transferring lamports from the vault inside `validate_and_execute`
- extend policies with tx/day and slippage limits
- persist rejected attempts as on-chain `TransactionLog` PDAs with reason codes
- add funding/withdraw flows and LiteSVM coverage for approvals and rejections

## Testing
- cargo test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added program-controlled vault with fund and withdraw operations for guarded transfers.
  * Daily transaction count limits now configurable per policy.
  * Slippage tolerance limits with basis-point thresholds now enforced.
  * Rejected transactions recorded on-chain with reason codes instead of failing execution.
  * New rejection events with detailed diagnostic information for enhanced audit trails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->