### PR TITLE
Stabilize local build and test workflow

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,4 +1,5 @@
 [toolchain]
+anchor_version = "0.32.1"
 package_manager = "yarn"
 
 [features]
@@ -6,7 +7,7 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-solana_guard = "FRuK1VzhqjybBMhp8UGVipJ9jkyuT9Dy7YJHAREwSApw"
+solana_guard = "5Tk7LXUpzRTWsDLXRiUUirJVv3Jne53F2DTq7xAqMey"
 
 [provider]
 cluster = "localnet"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,117 +3,12 @@
 version = 4
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "aes-gcm-siv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "polyval",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "agave-feature-set"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6200f3b8cfbe5992fde00d443f60e62a79d2d8f6a658af1ffb7c4f0baa3c7028"
-dependencies = [
- "ahash",
- "solana-epoch-schedule",
- "solana-hash 3.1.0",
- "solana-pubkey 3.0.0",
- "solana-sha256-hasher",
- "solana-svm-feature-set",
-]
-
-[[package]]
-name = "agave-reserved-account-keys"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3998a6ec388df954d8f78eeaf73ff487b50a8bdaebd48c8573af22c7b6db72"
-dependencies = [
- "agave-feature-set",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "agave-syscalls"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5212f0b24fc37d4c844ae25b563d0cf5587d092912820c40f88d4b9b301148f8"
-dependencies = [
- "bincode",
- "libsecp256k1",
- "num-traits",
- "solana-account",
- "solana-account-info",
- "solana-big-mod-exp",
- "solana-blake3-hasher",
- "solana-bn254",
- "solana-clock",
- "solana-cpi",
- "solana-curve25519",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-keccak-hasher",
- "solana-loader-v3-interface",
- "solana-poseidon",
- "solana-program-entrypoint",
- "solana-program-runtime",
- "solana-pubkey 3.0.0",
- "solana-sbpf",
- "solana-sdk-ids",
- "solana-secp256k1-recover",
- "solana-sha256-hasher",
- "solana-stable-layout",
- "solana-stake-interface",
- "solana-svm-callback",
- "solana-svm-feature-set",
- "solana-svm-log-collector",
- "solana-svm-measure",
- "solana-svm-timings",
- "solana-svm-type-overrides",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-transaction-context",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -129,27 +24,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anchor-attribute-access-control"
-version = "1.0.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b972f5fbd02524c92e4eb487c3c648904572702670f3d6fc81aef5f1751b1569"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-account"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9acfcb07a92084bcfa9f6cc49a5c2e8e0e986f25f4b7caa184b7a2c9c9e561c2"
+checksum = "7a883ca44ef14b2113615fc6d3a85fefc68b5002034e88db37f7f1f802f88aa9"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -158,10 +36,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-attribute-constant"
-version = "1.0.0"
+name = "anchor-attribute-account"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f46cc38f819377f07663b8eb492a701427950065e79d2d7b622a782443deb7a"
+checksum = "61c4d97763b29030412b4b80715076377edc9cc63bc3c9e667297778384b9fd2"
+dependencies = [
+ "anchor-syn",
+ "bs58",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-constant"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae3328bbf9bbd517a51621b1ba6cbec06cbbc25e8cfc7403bddf69bcf088206"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -170,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "1.0.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c34748789107c9838329e058ca7b253e67f37b39ceae5a0a6c8d99f5d1bf1fe"
+checksum = "cf2398a6d9e16df1ee9d7d37d970a8246756de898c8dd16ef6bdbe4da20cf39a"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -181,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "1.0.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a28a3e5eefa03d9c5ef02b2139198f652547d38dddafc9c5545152dfba54556"
+checksum = "f12758f4ec2f0e98d4d56916c6fe95cb23d74b8723dd902c762c5ef46ebe7b65"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -193,24 +84,26 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "1.0.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfaa03865053cb168bfc4debe5992be87f397aa027dd81b69a2e44f2e5bae1c5"
+checksum = "8c7193b5af2649813584aae6e3569c46fd59616a96af2083c556b13136c3830f"
 dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
  "anyhow",
+ "bs58",
  "heck",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "1.0.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef330db08f9ceee45c18ef96b15b869883d280c0ab5c6ff5d2e2f6481da7911"
+checksum = "d332d1a13c0fca1a446de140b656e66110a5e8406977dcb6a41e5d6f323760b0"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -219,12 +112,12 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-serde"
-version = "1.0.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e80ff4e3ddb8c85aafd37926335c28f820516311e7106e5b7482b42e798aaa"
+checksum = "8656e4af182edaeae665fa2d2d7ee81148518b5bd0be9a67f2a381bb17da7d46"
 dependencies = [
  "anchor-syn",
- "proc-macro-crate",
+ "borsh-derive-internal",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -232,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-space"
-version = "1.0.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2672af0ef4dfd5f5b6199355867b580cd8b4048093ef5208dd2b441305c15b8b"
+checksum = "dcff2a083560cd79817db07d89a4de39a2c4b2eaa00c1742cf0df49b25ff2bed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -243,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "1.0.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de9dce227fa0c08be20fef008c5b04681e1e0a15cb396e9619a9a1f800ff6cd"
+checksum = "e67d85d5376578f12d840c29ff323190f6eecd65b00a0b5f2b2f232751d049cc"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -259,13 +152,12 @@ dependencies = [
  "anchor-lang-idl",
  "base64 0.21.7",
  "bincode",
- "borsh",
+ "borsh 0.10.4",
  "bytemuck",
- "const-crypto",
  "solana-account-info",
  "solana-clock",
  "solana-cpi",
- "solana-define-syscall 3.0.0",
+ "solana-define-syscall",
  "solana-feature-gate-interface",
  "solana-instruction",
  "solana-instructions-sysvar",
@@ -277,13 +169,12 @@ dependencies = [
  "solana-program-memory",
  "solana-program-option",
  "solana-program-pack",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
  "solana-sdk-ids",
- "solana-stake-interface",
- "solana-system-interface 2.0.0",
+ "solana-system-interface",
  "solana-sysvar",
  "solana-sysvar-id",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -298,7 +189,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -313,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-syn"
-version = "1.0.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62f42cb7e348c033bd9bfba59979bcd66431c026ba23490af94045aa357a950"
+checksum = "b93b69aa7d099b59378433f6d7e20e1008fc10c69e48b220270e5b3f2ec4c8be"
 dependencies = [
  "anyhow",
  "bs58",
@@ -324,18 +215,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "sha2 0.10.9",
+ "serde_json",
+ "sha2",
  "syn 1.0.109",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
+ "thiserror",
 ]
 
 [[package]]
@@ -345,281 +228,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "ark-bn254"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
-dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-bn254"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
-dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-poly 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
-dependencies = [
- "ahash",
- "ark-ff 0.5.0",
- "ark-poly 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "educe",
- "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint 0.4.6",
- "num-traits",
- "paste",
- "rustc_version",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
-dependencies = [
- "ark-ff-asm 0.5.0",
- "ark-ff-macros 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "arrayvec",
- "digest 0.10.7",
- "educe",
- "itertools 0.13.0",
- "num-bigint 0.4.6",
- "num-traits",
- "paste",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
-dependencies = [
- "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "educe",
- "fnv",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-serialize-derive 0.4.2",
- "ark-std 0.4.0",
- "digest 0.10.7",
- "num-bigint 0.4.6",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
-dependencies = [
- "ark-serialize-derive 0.5.0",
- "ark-std 0.5.0",
- "arrayvec",
- "digest 0.10.7",
- "num-bigint 0.4.6",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "ascii"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -632,12 +244,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -655,30 +261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "blake3"
-version = "1.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,12 +270,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
+name = "borsh"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
- "hybrid-array",
+ "borsh-derive 0.10.4",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -702,9 +285,22 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 1.6.1",
  "bytes",
  "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831213f80d9423998dd696e2c5345aba6be7a0bd8cd19e31c5243e13df1cef89"
+dependencies = [
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -714,10 +310,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65d6ba50644c98714aa2a70d13d7df3cd75cd2b523a2b452bf010443800976b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276691d96f063427be83e6692b86148e488ebba9f48f77788724ca027ba3b6d4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -766,12 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,17 +396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
 dependencies = [
  "serde",
- "toml",
-]
-
-[[package]]
-name = "cc"
-version = "1.2.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
-dependencies = [
- "find-msvc-tools",
- "shlex",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -810,68 +412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "cfg_eval"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common 0.1.7",
- "inout",
-]
-
-[[package]]
-name = "cmov"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
-
-[[package]]
-name = "combine"
-version = "3.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
-dependencies = [
- "ascii",
- "byteorder",
- "either",
- "memchr",
- "unreachable",
-]
-
-[[package]]
-name = "const-crypto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c06f1eb05f06cf2e380fdded278fbf056a38974299d77960555a311dcf91a52"
-dependencies = [
- "keccak-const",
- "sha2-const-stable",
-]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,68 +421,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
 ]
 
 [[package]]
@@ -952,13 +437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
- "rand_core 0.6.4",
+ "rand_core",
  "rustc_version",
- "serde",
  "subtle",
  "zeroize",
 ]
@@ -975,253 +459,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
-name = "derivation-path"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "const-oid",
- "crypto-common 0.1.7",
- "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
- "ctutils",
-]
-
-[[package]]
-name = "eager"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe71d579d1812060163dff96056261deb5bf6729b100fa2e36a68b9649ba3d3"
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "educe"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd242f399be1da0a5354aa462d57b4ab2b4ee0683cc552f7c007d2d12d36e94"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "enum-ordinalize"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1237,56 +481,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
 name = "five8"
-version = "1.0.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
+checksum = "a75b8549488b4715defcb0d8a8a1c1c76a80661b5fa106b4ca0e7fce59d7d875"
 dependencies = [
  "five8_core",
 ]
 
 [[package]]
 name = "five8_const"
-version = "1.0.0"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
+checksum = "26dec3da8bc3ef08f2c04f61eab298c3ab334523e55f076354d6d6f613799a7b"
 dependencies = [
  "five8_core",
 ]
 
 [[package]]
 name = "five8_core"
-version = "1.0.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
 
 [[package]]
 name = "generic-array"
@@ -1296,18 +518,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1319,40 +529,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1362,15 +540,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
 ]
 
 [[package]]
@@ -1389,30 +558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,51 +565,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1484,35 +584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "k256"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2 0.10.9",
- "signature",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
-dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak-const"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d8d8ce877200136358e0bbff3a77965875db3af755a11e1fa6b1b3e2df13ea"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,139 +594,6 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "libsecp256k1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
-dependencies = [
- "arrayref",
- "base64 0.12.3",
- "digest 0.9.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "light-poseidon"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
-dependencies = [
- "ark-bn254 0.4.0",
- "ark-ff 0.4.2",
- "num-bigint 0.4.6",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "light-poseidon"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a1ccadd0bb5a32c196da536fd72c59183de24a055f6bf0513bf845fefab862"
-dependencies = [
- "ark-bn254 0.5.0",
- "ark-ff 0.5.0",
- "num-bigint 0.4.6",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "litesvm"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6d4edace08253a908d301768f291a7115e8e19e13473dd6e1ace78d6366433"
-dependencies = [
- "agave-feature-set",
- "agave-reserved-account-keys",
- "agave-syscalls",
- "ansi_term",
- "bincode",
- "indexmap",
- "itertools 0.14.0",
- "log",
- "serde",
- "solana-account",
- "solana-address 2.6.0",
- "solana-address-lookup-table-interface",
- "solana-bpf-loader-program",
- "solana-builtins",
- "solana-clock",
- "solana-compute-budget",
- "solana-compute-budget-instruction",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee",
- "solana-fee-structure",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-keypair",
- "solana-last-restart-slot",
- "solana-loader-v3-interface",
- "solana-loader-v4-interface",
- "solana-message",
- "solana-native-token",
- "solana-nonce",
- "solana-nonce-account",
- "solana-precompile-error",
- "solana-program-error",
- "solana-program-runtime",
- "solana-rent",
- "solana-sdk-ids",
- "solana-sha256-hasher",
- "solana-signature",
- "solana-signer",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stake-interface",
- "solana-svm-callback",
- "solana-svm-log-collector",
- "solana-svm-timings",
- "solana-svm-transaction",
- "solana-system-interface 2.0.0",
- "solana-system-program",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-transaction",
- "solana-transaction-context",
- "solana-transaction-error",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "lock_api"
@@ -1679,106 +617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
-name = "num"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
-dependencies = [
- "num-bigint 0.2.6",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint 0.2.6",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,12 +630,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "parking_lot"
@@ -1823,70 +655,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "proc-macro-crate"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pastey"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "percentage"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
-dependencies = [
- "num",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -1908,26 +682,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qstring"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "qualifier_attr"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,110 +691,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -2081,22 +735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,20 +756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,15 +769,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2209,81 +824,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
-dependencies = [
- "serde_core",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2-const-stable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
-
-[[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest 0.10.7",
- "keccak",
-]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2293,222 +841,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "solana-account"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc0ed36decb689413b9da5d57f2be49eea5bebb3cf7897015167b0c4336e731"
-dependencies = [
- "bincode",
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-account-info",
- "solana-clock",
- "solana-instruction-error",
- "solana-pubkey 4.2.0",
- "solana-sdk-ids",
- "solana-sysvar",
-]
-
-[[package]]
 name = "solana-account-info"
-version = "3.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
+checksum = "c8f5152a288ef1912300fc6efa6c2d1f9bb55d9398eb6c72326360b8063987da"
 dependencies = [
- "solana-address 2.6.0",
  "solana-program-error",
  "solana-program-memory",
-]
-
-[[package]]
-name = "solana-address"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
-dependencies = [
- "solana-address 2.6.0",
-]
-
-[[package]]
-name = "solana-address"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1384b52c435a750cc9c538760fc7bb472fd78e65a9900a2d07312c5bb335b72"
-dependencies = [
- "borsh",
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
- "five8",
- "five8_const",
- "serde",
- "serde_derive",
- "sha2-const-stable",
- "solana-atomic-u64",
- "solana-define-syscall 5.1.0",
- "solana-program-error",
- "solana-sanitize",
- "solana-sha256-hasher",
- "wincode",
-]
-
-[[package]]
-name = "solana-address-lookup-table-interface"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115b4f773acc4f3f3cb986b0d335e9845c0368c82b0940410935bc11ae065578"
-dependencies = [
- "bincode",
- "bytemuck",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-instruction",
- "solana-instruction-error",
- "solana-pubkey 4.2.0",
- "solana-sdk-ids",
- "solana-slot-hashes",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-atomic-u64"
-version = "3.0.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085db4906d89324cef2a30840d59eaecf3d4231c560ec7c9f6614a93c652f501"
+checksum = "d52e52720efe60465b052b9e7445a01c17550666beec855cce66f44766697bc2"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
-name = "solana-big-mod-exp"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "solana-define-syscall 3.0.0",
-]
-
-[[package]]
-name = "solana-bincode"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278a1a5bad62cd9da89ac8d4b7ec444e83caa8ae96aa656dfc27684b28d49a5d"
-dependencies = [
- "bincode",
- "serde_core",
- "solana-instruction-error",
-]
-
-[[package]]
-name = "solana-blake3-hasher"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
-dependencies = [
- "blake3",
- "solana-define-syscall 4.0.1",
- "solana-hash 4.3.0",
-]
-
-[[package]]
-name = "solana-bn254"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ff13a8867fcc7b0f1114764e1bf6191b4551dcaf93729ddc676cd4ec6abc9f"
-dependencies = [
- "ark-bn254 0.5.0",
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "bytemuck",
- "solana-define-syscall 5.1.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-borsh"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04abbae16f57178a163125805637b8a076175bb5c0002fb04f4792bea901cf7"
-dependencies = [
- "borsh",
-]
-
-[[package]]
-name = "solana-bpf-loader-program"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044a6c5327755992853454ea5ec495edd987dab53a6f9029e695bf0d43ab55dc"
-dependencies = [
- "agave-syscalls",
- "bincode",
- "qualifier_attr",
- "solana-account",
- "solana-bincode",
- "solana-clock",
- "solana-instruction",
- "solana-loader-v3-interface",
- "solana-loader-v4-interface",
- "solana-packet",
- "solana-program-entrypoint",
- "solana-program-runtime",
- "solana-pubkey 3.0.0",
- "solana-sbpf",
- "solana-sdk-ids",
- "solana-svm-feature-set",
- "solana-svm-log-collector",
- "solana-svm-measure",
- "solana-svm-type-overrides",
- "solana-system-interface 2.0.0",
- "solana-transaction-context",
-]
-
-[[package]]
-name = "solana-builtins"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf44075aa3dbe16ce0112314d0dfd2435a18ddfd96f53e5269879f4006eb60d"
-dependencies = [
- "agave-feature-set",
- "solana-bpf-loader-program",
- "solana-compute-budget-program",
- "solana-hash 3.1.0",
- "solana-loader-v4-program",
- "solana-program-runtime",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-system-program",
- "solana-vote-program",
- "solana-zk-elgamal-proof-program",
- "solana-zk-token-proof-program",
-]
-
-[[package]]
-name = "solana-builtins-default-costs"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cd4d41f391f427e64e03fb00fb0c93443f18464dafd71e06f996ac03a3982"
-dependencies = [
- "agave-feature-set",
- "ahash",
- "log",
- "solana-bpf-loader-program",
- "solana-compute-budget-program",
- "solana-loader-v4-program",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-system-program",
- "solana-vote-program",
-]
-
-[[package]]
 name = "solana-clock"
-version = "3.0.1"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cf11109c3b6115cc510f1e31f06fdd52f504271bc24ef5f1249fbbcae5f9f3"
+checksum = "f8584296123df8fe229b95e2ebfd37ae637fe9db9b7d4dd677ac5a78e80dbfce"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2518,122 +874,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-compute-budget"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55267bed68ed018f6b2fd5e2f7ae694cbcb1a9bfd98b749803e94be7b5f08774"
-dependencies = [
- "solana-fee-structure",
- "solana-program-runtime",
-]
-
-[[package]]
-name = "solana-compute-budget-instruction"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bf47dcc57b770cee0432899ac89cd7e85896f9e28e3d5e5542a0b8a8f5839f"
-dependencies = [
- "agave-feature-set",
- "log",
- "solana-borsh",
- "solana-builtins-default-costs",
- "solana-compute-budget",
- "solana-compute-budget-interface",
- "solana-instruction",
- "solana-packet",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-svm-transaction",
- "solana-transaction-error",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-compute-budget-interface"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8292c436b269ad23cecc8b24f7da3ab07ca111661e25e00ce0e1d22771951ab9"
-dependencies = [
- "borsh",
- "solana-instruction",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-compute-budget-program"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc87532d1ca1b871204cdb103514182bd9460cea403c16f22ca49e1ba063ea1"
-dependencies = [
- "solana-program-runtime",
-]
-
-[[package]]
 name = "solana-cpi"
-version = "3.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dea26709d867aada85d0d3617db0944215c8bb28d3745b912de7db13a23280c"
+checksum = "8dc71126edddc2ba014622fc32d0f5e2e78ec6c5a1e0eb511b85618c09e9ea11"
 dependencies = [
  "solana-account-info",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey",
  "solana-stable-layout",
 ]
 
 [[package]]
-name = "solana-curve25519"
-version = "3.1.12"
+name = "solana-decode-error"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb091ac9c1e4d51c3cd1893444aee607cd1b0173c4ba0b557f8960844f44a1b"
+checksum = "8c781686a18db2f942e70913f7ca15dc120ec38dcab42ff7557db2c70c625a35"
 dependencies = [
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
- "solana-define-syscall 3.0.0",
- "subtle",
- "thiserror 2.0.18",
+ "num-traits",
 ]
 
 [[package]]
 name = "solana-define-syscall"
-version = "3.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
-
-[[package]]
-name = "solana-define-syscall"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
-
-[[package]]
-name = "solana-define-syscall"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
-
-[[package]]
-name = "solana-derivation-path"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff71743072690fdbdfcdc37700ae1cb77485aaad49019473a81aee099b1e0b8c"
-dependencies = [
- "derivation-path",
- "qstring",
- "uriparse",
-]
+checksum = "2ae3e2abcf541c8122eafe9a625d4d194b4023c20adde1e251f94e056bb1aee2"
 
 [[package]]
 name = "solana-epoch-rewards"
-version = "3.0.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e7b0ba210593ba8ddd39d6d234d81795d1671cebf3026baa10d5dc23ac42f0"
+checksum = "86b575d3dd323b9ea10bb6fe89bf6bf93e249b215ba8ed7f68f1a3633f384db7"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.3.0",
+ "solana-hash",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -2641,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-schedule"
-version = "3.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce264b7b42322325947c4136a09460bf5c73d9aa8262c9b0a2064be63ba8639"
+checksum = "3fce071fbddecc55d727b1d7ed16a629afe4f6e4c217bc8d00af3b785f6f67ed"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2654,31 +931,19 @@ dependencies = [
 
 [[package]]
 name = "solana-feature-gate-interface"
-version = "3.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ca9b5cbb6f500f7fd73db5bd95640f71a83f04d6121a0e59a43b202dca2731"
+checksum = "43f5c5382b449e8e4e3016fb05e418c53d57782d8b5c30aa372fc265654b956d"
 dependencies = [
- "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey",
  "solana-sdk-ids",
 ]
 
 [[package]]
-name = "solana-fee"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c7ab7f31d404a130c78c29a7a845cd599b2623fa335e5fcaef2bd7b3be83e6"
-dependencies = [
- "agave-feature-set",
- "solana-fee-structure",
- "solana-svm-transaction",
-]
-
-[[package]]
 name = "solana-fee-calculator"
-version = "3.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e8add96b5741573e9f7529c4bb7719cfcfa999c3847a68cdfaef0cb6adf567"
+checksum = "d89bc408da0fb3812bc3008189d148b4d3e08252c79ad810b245482a3f70cd8d"
 dependencies = [
  "log",
  "serde",
@@ -2686,87 +951,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-fee-structure"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2abdb1223eea8ec64136f39cb1ffcf257e00f915c957c35c0dd9e3f4e700b0"
-
-[[package]]
 name = "solana-guard"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "litesvm",
- "solana-keypair",
- "solana-message",
- "solana-signer",
- "solana-transaction",
 ]
 
 [[package]]
 name = "solana-hash"
-version = "3.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
+checksum = "b5b96e9f0300fa287b545613f007dfe20043d7812bee255f418c1eb649c93b63"
 dependencies = [
- "solana-hash 4.3.0",
-]
-
-[[package]]
-name = "solana-hash"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b113239362cee7093bfb250467138f079a2a03673181dc15bff6ccd677912d"
-dependencies = [
- "borsh",
  "bytemuck",
  "bytemuck_derive",
  "five8",
+ "js-sys",
  "serde",
  "serde_derive",
  "solana-atomic-u64",
  "solana-sanitize",
- "wincode",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-instruction"
-version = "3.4.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
+checksum = "bab5682934bd1f65f8d2c16f21cb532526fcc1a09f796e2cacdb091eee5774ad"
 dependencies = [
  "bincode",
- "serde",
- "serde_derive",
- "solana-define-syscall 5.1.0",
- "solana-instruction-error",
- "solana-pubkey 4.2.0",
-]
-
-[[package]]
-name = "solana-instruction-error"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b188842592fdf6cb96f55263ae1bf11713ab5114401d1d5a881ed7cc41bef6"
-dependencies = [
+ "getrandom",
+ "js-sys",
  "num-traits",
  "serde",
  "serde_derive",
- "solana-program-error",
+ "serde_json",
+ "solana-define-syscall",
+ "solana-pubkey",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-instructions-sysvar"
-version = "3.0.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddf67876c541aa1e21ee1acae35c95c6fbc61119814bfef70579317a5e26955"
+checksum = "e0e85a6fad5c2d0c4f5b91d34b8ca47118fc593af706e523cdbedf846a954f57"
 dependencies = [
  "bitflags",
  "solana-account-info",
  "solana-instruction",
- "solana-instruction-error",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-serialize-utils",
@@ -2775,49 +1011,22 @@ dependencies = [
 
 [[package]]
 name = "solana-invoke"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4065031f5c7dd29ef5f5003c1a353011eeabbafa6c5a5033da0cedbfca824b94"
+checksum = "58f5693c6de226b3626658377168b0184e94e8292ff16e3d31d4766e65627565"
 dependencies = [
  "solana-account-info",
- "solana-define-syscall 3.0.0",
+ "solana-define-syscall",
  "solana-instruction",
  "solana-program-entrypoint",
  "solana-stable-layout",
 ]
 
 [[package]]
-name = "solana-keccak-hasher"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
-dependencies = [
- "sha3",
- "solana-define-syscall 4.0.1",
- "solana-hash 4.3.0",
-]
-
-[[package]]
-name = "solana-keypair"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "263d614c12aa267a3278703175fd6440552ca61bc960b5a02a4482720c53438b"
-dependencies = [
- "ed25519-dalek",
- "five8",
- "five8_core",
- "rand 0.9.4",
- "solana-address 2.6.0",
- "solana-seed-phrase",
- "solana-signature",
- "solana-signer",
-]
-
-[[package]]
 name = "solana-last-restart-slot"
-version = "3.0.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcda154ec827f5fc1e4da0af3417951b7e9b8157540f81f936c4a8b1156134d0"
+checksum = "4a6360ac2fdc72e7463565cd256eedcf10d7ef0c28a1249d261ec168c1b55cdd"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2828,264 +1037,109 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "6.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0538d4dbc9022e01616f1c58f2db98ece739c5d5ed4a2ef8737a953e76a2d4"
+checksum = "fa4be76cfa9afd84ca2f35ebc09f0da0f0092935ccdac0595d98447f259538c2"
 dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
  "solana-instruction",
- "solana-pubkey 4.2.0",
+ "solana-pubkey",
  "solana-sdk-ids",
- "solana-system-interface 3.2.0",
-]
-
-[[package]]
-name = "solana-loader-v4-interface"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c948b33ff81fa89699911b207059e493defdba9647eaf18f23abdf3674e0fb"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-system-interface 2.0.0",
-]
-
-[[package]]
-name = "solana-loader-v4-program"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e88b98ba6b408fe6fcf180784fc378d07ae63100c7dd413ff97474b6de30c5d"
-dependencies = [
- "log",
- "solana-account",
- "solana-bincode",
- "solana-bpf-loader-program",
- "solana-instruction",
- "solana-loader-v3-interface",
- "solana-loader-v4-interface",
- "solana-packet",
- "solana-program-runtime",
- "solana-pubkey 3.0.0",
- "solana-sbpf",
- "solana-sdk-ids",
- "solana-svm-log-collector",
- "solana-svm-measure",
- "solana-svm-type-overrides",
- "solana-transaction-context",
-]
-
-[[package]]
-name = "solana-message"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0448b1fd891c5f46491e5dc7d9986385ba3c852c340db2911dd29faa01d2b08d"
-dependencies = [
- "bincode",
- "blake3",
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-address 2.6.0",
- "solana-hash 4.3.0",
- "solana-instruction",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-short-vec",
- "solana-transaction-error",
+ "solana-system-interface",
 ]
 
 [[package]]
 name = "solana-msg"
-version = "3.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
+checksum = "f36a1a14399afaabc2781a1db09cb14ee4cc4ee5c7a5a3cfcc601811379a8092"
 dependencies = [
- "solana-define-syscall 5.1.0",
-]
-
-[[package]]
-name = "solana-native-token"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
-
-[[package]]
-name = "solana-nonce"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95dbc9f2e33b6c10e231df15cb2a3bff9ea7eab6347f9e316fe75c97fd67bbb"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-fee-calculator",
- "solana-hash 4.3.0",
- "solana-pubkey 4.2.0",
- "solana-sha256-hasher",
-]
-
-[[package]]
-name = "solana-nonce-account"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805fd25b29e5a1a0e6c3dd6320c9da80f275fbe4ff6e392617c303a2085c435e"
-dependencies = [
- "solana-account",
- "solana-hash 3.1.0",
- "solana-nonce",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-packet"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edf2f25743c95229ac0fdc32f8f5893ef738dbf332c669e9861d33ddb0f469d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "solana-poseidon"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44739c6c9f717fd057f7c16fba65fdd3628d4918c61c399520e6f4fba5ad854"
-dependencies = [
- "ark-bn254 0.4.0",
- "ark-bn254 0.5.0",
- "light-poseidon 0.2.0",
- "light-poseidon 0.4.0",
- "solana-define-syscall 3.0.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-precompile-error"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafcd950de74c6c39d55dc8ca108bbb007799842ab370ef26cf45a34453c31e1"
-dependencies = [
- "num-traits",
+ "solana-define-syscall",
 ]
 
 [[package]]
 name = "solana-program-entrypoint"
-version = "3.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c9b0a1ff494e05f503a08b3d51150b73aa639544631e510279d6375f290997"
+checksum = "32ce041b1a0ed275290a5008ee1a4a6c48f5054c8a3d78d313c08958a06aedbd"
 dependencies = [
  "solana-account-info",
- "solana-define-syscall 4.0.1",
+ "solana-msg",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-program-error"
-version = "3.0.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
+checksum = "9ee2e0217d642e2ea4bee237f37bd61bb02aec60da3647c48ff88f6556ade775"
 dependencies = [
- "borsh",
+ "borsh 1.6.1",
+ "num-traits",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-program-memory"
-version = "3.1.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4068648649653c2c50546e9a7fb761791b5ab0cda054c771bb5808d3a4b9eb52"
+checksum = "3a5426090c6f3fd6cfdc10685322fede9ca8e5af43cd6a59e98bfe4e91671712"
 dependencies = [
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall",
 ]
 
 [[package]]
 name = "solana-program-option"
-version = "3.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a88006a9b8594088cec9027ab77caaaa258a2aaa2083d3f086c44b42e50aeab"
+checksum = "dc677a2e9bc616eda6dbdab834d463372b92848b2bfe4a1ed4e4b4adba3397d0"
 
 [[package]]
 name = "solana-program-pack"
-version = "3.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7701cb15b90667ae1c89ef4ac35a59c61e66ce58ddee13d729472af7f41d59"
+checksum = "319f0ef15e6e12dc37c597faccb7d62525a509fec5f6975ecb9419efddeb277b"
 dependencies = [
  "solana-program-error",
 ]
 
 [[package]]
-name = "solana-program-runtime"
-version = "3.1.12"
+name = "solana-pubkey"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a7bb03e9d73082c4eced105102b88f1d6ec6856b020f17ec89043bcf9dbdda"
+checksum = "9b62adb9c3261a052ca1f999398c388f1daf558a1b492f60a6d9e64857db4ff1"
 dependencies = [
- "base64 0.22.1",
- "bincode",
- "itertools 0.12.1",
- "log",
- "percentage",
- "rand 0.8.6",
+ "borsh 0.10.4",
+ "borsh 1.6.1",
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek",
+ "five8",
+ "five8_const",
+ "getrandom",
+ "js-sys",
+ "num-traits",
  "serde",
- "solana-account",
- "solana-account-info",
- "solana-clock",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee-structure",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-last-restart-slot",
- "solana-loader-v3-interface",
- "solana-program-entrypoint",
- "solana-pubkey 3.0.0",
- "solana-rent",
- "solana-sbpf",
- "solana-sdk-ids",
- "solana-slot-hashes",
- "solana-stable-layout",
- "solana-stake-interface",
- "solana-svm-callback",
- "solana-svm-feature-set",
- "solana-svm-log-collector",
- "solana-svm-measure",
- "solana-svm-timings",
- "solana-svm-transaction",
- "solana-svm-type-overrides",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-transaction-context",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-pubkey"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
-dependencies = [
- "solana-address 1.1.0",
-]
-
-[[package]]
-name = "solana-pubkey"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
-dependencies = [
- "solana-address 2.6.0",
+ "serde_derive",
+ "solana-atomic-u64",
+ "solana-decode-error",
+ "solana-define-syscall",
+ "solana-sanitize",
+ "solana-sha256-hasher",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-rent"
-version = "3.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e860d5499a705369778647e97d760f7670adfb6fc8419dd3d568deccd46d5487"
+checksum = "d1aea8fdea9de98ca6e8c2da5827707fb3842833521b528a713810ca685d2480"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3096,41 +1150,24 @@ dependencies = [
 
 [[package]]
 name = "solana-sanitize"
-version = "3.0.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
-
-[[package]]
-name = "solana-sbpf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15b079e08471a9dbfe1e48b2c7439c85aa2a055cbd54eddd8bd257b0a7dbb29"
-dependencies = [
- "byteorder",
- "combine",
- "hash32",
- "libc",
- "log",
- "rand 0.8.6",
- "rustc-demangle",
- "thiserror 2.0.18",
- "winapi",
-]
+checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
 
 [[package]]
 name = "solana-sdk-ids"
-version = "3.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
+checksum = "5c5d8b9cc68d5c88b062a33e23a6466722467dde0035152d8fb1afbcdf350a5f"
 dependencies = [
- "solana-address 2.6.0",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "3.0.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8765316242300c48242d84a41614cb3388229ec353ba464f6fe62a733e41806f"
+checksum = "86280da8b99d03560f6ab5aca9de2e38805681df34e0bb8f238e69b29433b9df"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -3139,120 +1176,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-secp256k1-recover"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5f18893d62e6c73117dcba48f8f5e3266d90e5ec3d0a0a90f9785adac36c1"
-dependencies = [
- "k256",
- "solana-define-syscall 5.1.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-seed-derivable"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7bdb72758e3bec33ed0e2658a920f1f35dfb9ed576b951d20d63cb61ecd95c"
-dependencies = [
- "solana-derivation-path",
-]
-
-[[package]]
-name = "solana-seed-phrase"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
-dependencies = [
- "hmac",
- "pbkdf2",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "solana-serde-varint"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950e5b83e839dc0f92c66afc124bb8f40e89bc90f0579e8ec5499296d27f54e3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "solana-serialize-utils"
-version = "3.1.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7cc401931d178472358e6b78dc72d031dc08f752d7410f0e8bd259dd6f02fa"
+checksum = "817a284b63197d2b27afdba829c5ab34231da4a9b4e763466a003c40ca4f535e"
 dependencies = [
- "solana-instruction-error",
- "solana-pubkey 4.2.0",
+ "solana-instruction",
+ "solana-pubkey",
  "solana-sanitize",
 ]
 
 [[package]]
 name = "solana-sha256-hasher"
-version = "3.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
+checksum = "5aa3feb32c28765f6aa1ce8f3feac30936f16c5c3f7eb73d63a5b8f6f8ecdc44"
 dependencies = [
- "sha2 0.10.9",
- "solana-define-syscall 4.0.1",
- "solana-hash 4.3.0",
-]
-
-[[package]]
-name = "solana-short-vec"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3bd991c2cc415291c86bb0b6b4d53e93d13bb40344e4c5a2884e0e4f5fa93f"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "solana-signature"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a73c6e97cc2108be0adf6a6ea326434f8398df9d7eed81da2a4548b69e971c"
-dependencies = [
- "ed25519-dalek",
- "five8",
- "serde",
- "serde-big-array",
- "serde_derive",
- "solana-sanitize",
- "wincode",
-]
-
-[[package]]
-name = "solana-signer"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bfea97951fee8bae0d6038f39a5efcb6230ecdfe33425ac75196d1a1e3e3235"
-dependencies = [
- "solana-pubkey 3.0.0",
- "solana-signature",
- "solana-transaction-error",
+ "sha2",
+ "solana-define-syscall",
+ "solana-hash",
 ]
 
 [[package]]
 name = "solana-slot-hashes"
-version = "3.0.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2585f70191623887329dfb5078da3a00e15e3980ea67f42c2e10b07028419f43"
+checksum = "0c8691982114513763e88d04094c9caa0376b867a29577939011331134c301ce"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.3.0",
+ "solana-hash",
  "solana-sdk-ids",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-slot-history"
-version = "3.0.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f914f6b108f5bba14a280b458d023e3621c9973f27f015a4d755b50e88d89e97"
+checksum = "97ccc1b2067ca22754d5283afb2b0126d61eae734fc616d23871b0943b0d935e"
 dependencies = [
  "bv",
  "serde",
@@ -3263,161 +1225,54 @@ dependencies = [
 
 [[package]]
 name = "solana-stable-layout"
-version = "3.0.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f6a291ba063a37780af29e7db14bdd3dc447584d8ba5b3fc4b88e2bbc982fa"
+checksum = "9f14f7d02af8f2bc1b5efeeae71bc1c2b7f0f65cd75bcc7d8180f2c762a57f54"
 dependencies = [
  "solana-instruction",
- "solana-pubkey 4.2.0",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-stake-interface"
-version = "2.0.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bc26191b533f9a6e5a14cca05174119819ced680a80febff2f5051a713f0db"
+checksum = "5269e89fde216b4d7e1d1739cf5303f8398a1ff372a81232abbee80e554a838c"
 dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
  "solana-clock",
  "solana-cpi",
+ "solana-decode-error",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
+ "solana-pubkey",
+ "solana-system-interface",
  "solana-sysvar-id",
 ]
 
 [[package]]
-name = "solana-svm-callback"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb521c7f62db21661267a933f0d311a76b2b744a766b46f5a9a9395ce70f687c"
-dependencies = [
- "solana-account",
- "solana-clock",
- "solana-precompile-error",
- "solana-pubkey 3.0.0",
-]
-
-[[package]]
-name = "solana-svm-feature-set"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08924d3b4918008d75a5807e73af8eb9f1c409067c772de518d1dd67dd4c03de"
-
-[[package]]
-name = "solana-svm-log-collector"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c071b3e4e9b2f19f15659abc74bd7fcc40cec6d60c1f6024384ff78cb49d40"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "solana-svm-measure"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e4f9972c93d50eaa299fadf1bee9de2055d47eef26af589dcefb487f22e71d"
-
-[[package]]
-name = "solana-svm-timings"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c65d4887002f8105f8e49253d0956292c55d66a1a3ee3594e7f90e682ed9521"
-dependencies = [
- "eager",
- "enum-iterator",
- "solana-pubkey 3.0.0",
-]
-
-[[package]]
-name = "solana-svm-transaction"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6ff55ce4c24e26ad8b0e67bc604cbd54eabfc94540c4c2c93e51fa087ead5"
-dependencies = [
- "solana-hash 3.1.0",
- "solana-message",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-signature",
- "solana-transaction",
-]
-
-[[package]]
-name = "solana-svm-type-overrides"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa888be46794b88f130508f694e989fb8802c823b9048acd4d0240e9818502fe"
-dependencies = [
- "rand 0.8.6",
-]
-
-[[package]]
 name = "solana-system-interface"
-version = "2.0.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1790547bfc3061f1ee68ea9d8dc6c973c02a163697b24263a8e9f2e6d4afa2"
+checksum = "94d7c18cb1a91c6be5f5a8ac9276a1d7c737e39a21beba9ea710ab4b9c63bc90"
 dependencies = [
+ "js-sys",
  "num-traits",
  "serde",
  "serde_derive",
+ "solana-decode-error",
  "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey 3.0.0",
-]
-
-[[package]]
-name = "solana-system-interface"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b54965bf0b76fa8e2b35376583efddd4d916618cfe595bf48c7d7b55a9e628"
-dependencies = [
- "num-traits",
- "serde",
- "serde_derive",
- "solana-address 2.6.0",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
-]
-
-[[package]]
-name = "solana-system-program"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e44e2abb14c34efbc0074f9009132f12ff66cc3ab1a7715d24b6801bb7f32"
-dependencies = [
- "bincode",
- "log",
- "serde",
- "solana-account",
- "solana-bincode",
- "solana-fee-calculator",
- "solana-instruction",
- "solana-nonce",
- "solana-nonce-account",
- "solana-packet",
- "solana-program-runtime",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-svm-log-collector",
- "solana-svm-type-overrides",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
- "solana-transaction-context",
+ "solana-pubkey",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-sysvar"
-version = "3.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690d3dd88f15c21edff68eb391ef8800df7a1f5cec84ee3e8d1abf05affdf74"
+checksum = "b8c3595f95069f3d90f275bb9bd235a1973c4d059028b0a7f81baca2703815db"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3426,264 +1281,37 @@ dependencies = [
  "serde_derive",
  "solana-account-info",
  "solana-clock",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.3.0",
+ "solana-hash",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-memory",
- "solana-pubkey 4.2.0",
+ "solana-pubkey",
  "solana-rent",
+ "solana-sanitize",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-slot-hashes",
  "solana-slot-history",
+ "solana-stake-interface",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-sysvar-id"
-version = "3.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
+checksum = "5762b273d3325b047cfda250787f8d796d781746860d5d0a746ee29f3e8812c1"
 dependencies = [
- "solana-address 2.6.0",
+ "solana-pubkey",
  "solana-sdk-ids",
 ]
-
-[[package]]
-name = "solana-transaction"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96697cff5075a028265324255efed226099f6d761ca67342b230d09f72cc48d2"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-address 2.6.0",
- "solana-hash 4.3.0",
- "solana-instruction",
- "solana-instruction-error",
- "solana-message",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-short-vec",
- "solana-signature",
- "solana-signer",
- "solana-transaction-error",
-]
-
-[[package]]
-name = "solana-transaction-context"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077ee5d6af12af9747cb14255a92ab79e830c5dabf9baaa8f4196299f476dfa0"
-dependencies = [
- "bincode",
- "serde",
- "solana-account",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-pubkey 3.0.0",
- "solana-rent",
- "solana-sbpf",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-transaction-error"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2165ad25b694c654d5395fc7a049452a192376e4c96a7fad05580f6ba5ba1c"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-instruction-error",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-vote-interface"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6e123e16bfdd7a81d71b4c4699e0b29580b619f4cd2ef5b6aae1eb85e8979f"
-dependencies = [
- "bincode",
- "cfg_eval",
- "num-derive",
- "num-traits",
- "serde",
- "serde_derive",
- "serde_with",
- "solana-clock",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-instruction-error",
- "solana-pubkey 3.0.0",
- "solana-rent",
- "solana-sdk-ids",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-short-vec",
- "solana-system-interface 2.0.0",
-]
-
-[[package]]
-name = "solana-vote-program"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7f37540da27c0ec132ee1b5380ad32d98663afba7ade3581f2d963fd2f63c2"
-dependencies = [
- "agave-feature-set",
- "bincode",
- "log",
- "num-derive",
- "num-traits",
- "serde",
- "solana-account",
- "solana-bincode",
- "solana-clock",
- "solana-epoch-schedule",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-keypair",
- "solana-packet",
- "solana-program-runtime",
- "solana-pubkey 3.0.0",
- "solana-rent",
- "solana-sdk-ids",
- "solana-signer",
- "solana-slot-hashes",
- "solana-transaction",
- "solana-transaction-context",
- "solana-vote-interface",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-zk-elgamal-proof-program"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee65de587e6fe912668903e62f3f40c02a834f21967a18cc6c71f550c51a639"
-dependencies = [
- "agave-feature-set",
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-instruction",
- "solana-program-runtime",
- "solana-sdk-ids",
- "solana-svm-log-collector",
- "solana-zk-sdk",
-]
-
-[[package]]
-name = "solana-zk-sdk"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9602bcb1f7af15caef92b91132ec2347e1c51a72ecdbefdaefa3eac4b8711475"
-dependencies = [
- "aes-gcm-siv",
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
- "getrandom 0.2.17",
- "itertools 0.12.1",
- "js-sys",
- "merlin",
- "num-derive",
- "num-traits",
- "rand 0.8.6",
- "serde",
- "serde_derive",
- "serde_json",
- "sha3",
- "solana-derivation-path",
- "solana-instruction",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-seed-derivable",
- "solana-seed-phrase",
- "solana-signature",
- "solana-signer",
- "subtle",
- "thiserror 2.0.18",
- "wasm-bindgen",
- "zeroize",
-]
-
-[[package]]
-name = "solana-zk-token-proof-program"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ecb5f2989632b030709c8aebdbc586a8c0f867d0ec154d0cb7feafb86f72fb"
-dependencies = [
- "agave-feature-set",
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-instruction",
- "solana-program-runtime",
- "solana-sdk-ids",
- "solana-svm-log-collector",
- "solana-zk-token-sdk",
-]
-
-[[package]]
-name = "solana-zk-token-sdk"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d27bcbe061cc3d4f25527ee4f28b04a9408294d46dd9b817b93cd3dd98d72d"
-dependencies = [
- "aes-gcm-siv",
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
- "itertools 0.12.1",
- "merlin",
- "num-derive",
- "num-traits",
- "rand 0.8.6",
- "serde",
- "serde_json",
- "sha3",
- "solana-curve25519",
- "solana-derivation-path",
- "solana-instruction",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-seed-derivable",
- "solana-seed-phrase",
- "solana-signature",
- "solana-signer",
- "subtle",
- "thiserror 2.0.18",
- "zeroize",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -3719,16 +1347,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3736,17 +1355,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3767,6 +1375,15 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml"
@@ -3858,66 +1475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common 0.1.7",
- "subtle",
-]
-
-[[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
-name = "uriparse"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
-dependencies = [
- "fnv",
- "lazy_static",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3965,53 +1532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wincode"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c754f1fc41250f2f742a27ba0fcc9f73df1dec23f6878490770855d43c322d"
-dependencies = [
- "pastey",
- "proc-macro2",
- "quote",
- "thiserror 2.0.18",
- "wincode-derive",
-]
-
-[[package]]
-name = "wincode-derive"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e070787599c7c067b89598cd3eda440cca1b69eda9e0ff7c725fc8679ce9eb4"
-dependencies = [
- "darling 0.21.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,12 +1554,6 @@ checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
@@ -4066,20 +1580,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zmij"

--- a/README.md
+++ b/README.md
@@ -12,34 +12,41 @@ AI agents are getting access to user wallets, but there's no on-chain mechanism 
 
 ## The Solution
 
-SolanaGuard is a Solana smart contract (built with Anchor/Rust) that acts as a **deterministic firewall** between AI agents and your funds. Users register an agent, set policies (max spend per tx, daily limit, allowed protocols), and the contract enforces these rules on every transaction.
+SolanaGuard is a Solana smart contract (built with Anchor/Rust) that acts as a **deterministic firewall** between AI agents and your funds. Users register an agent, fund a program-controlled vault, set policies (max spend per tx, daily limit, daily tx cap, allowed protocols, and slippage limit), and the contract enforces these rules while executing each guarded transfer from the vault itself.
 
 **No agent, no backend, and no developer can override them — enforcement happens at the blockchain level.**
 
 ## Features
 
 - 🔐 **Agent Registration** — Bind AI agents to your wallet with PDA-based identity
+- 🏦 **Program Vault** — Funds live in a PDA-controlled vault instead of an agent wallet
 - 📊 **Per-Transaction Limits** — Cap the maximum any single transaction can spend
 - 📅 **Daily Spending Limits** — Automatic 24-hour rolling reset
+- 🔢 **Daily Transaction Caps** — Limit how many approved actions an agent can take per day
 - ✅ **Protocol Allowlisting** — Whitelist only the programs your agent can interact with
+- 📉 **Slippage Limits** — Reject actions when reported slippage exceeds policy
 - 🚨 **Emergency Kill Switch** — Instantly pause any agent with one transaction
-- 📝 **On-chain Audit Trail** — Every transaction logged as a PDA for full transparency
+- 📝 **On-chain Audit Trail** — Every attempt is recorded as a PDA log; rejected attempts also emit events
 - 🔄 **Partial Policy Updates** — Modify individual policy fields without resetting everything
+
+Policy denials are recorded as successful on-chain audit entries with `was_approved = false` and a rejection reason code. This preserves a durable audit trail without moving funds from the guarded vault.
 
 ## Architecture
 
 ```
 ┌─────────────┐     ┌──────────────────┐     ┌─────────────────┐
-│   AI Agent   │────▶│   SolanaGuard    │────▶│  Target Protocol│
+│   AI Agent   │────▶│   SolanaGuard    │────▶│  Target Account │
 │  (e.g. GPT)  │     │  Smart Contract  │     │  (e.g. Jupiter) │
 └─────────────┘     │                  │     └─────────────────┘
                     │  ✓ Agent active? │
                     │  ✓ Under tx max? │
                     │  ✓ Under daily?  │
+                    │  ✓ Under tx/day? │
                     │  ✓ Protocol OK?  │
+                    │  ✓ Slippage OK?  │
                     │                  │
                     │  ❌ REJECT or    │
-                    │  ✅ APPROVE      │
+                    │  ✅ EXECUTE      │
                     └──────────────────┘
 ```
 
@@ -48,10 +55,12 @@ SolanaGuard is a Solana smart contract (built with Anchor/Rust) that acts as a *
 | Instruction | Who Calls | Description |
 |---|---|---|
 | `register_agent` | Owner | Register an AI agent under your ownership |
-| `set_policy` | Owner | Define spending limits and allowed protocols |
-| `validate_and_execute` | Agent | Check transaction against policy before executing |
+| `fund_vault` | Owner | Deposit SOL into the guarded vault |
+| `set_policy` | Owner | Define spending, tx-count, protocol, and slippage limits |
+| `validate_and_execute` | Agent | Enforce policy and execute the guarded transfer from the vault |
 | `toggle_agent` | Owner | Pause/unpause an agent (kill switch) |
 | `update_policy` | Owner | Partially update policy parameters |
+| `withdraw_vault` | Owner | Withdraw unused SOL back from the vault |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -78,15 +78,25 @@ Policy denials are recorded as successful on-chain audit entries with `was_appro
 git clone https://github.com/YOUR_USERNAME/solana-guard.git
 cd solana-guard
 
-# Build
-anchor build
+# Sync the local program id with the checked-in keypair
+yarn keys:sync
 
-# Test
-anchor test
+# Build the Solana program
+yarn build:program
+
+# Run host-side tests
+yarn test:host
 
 # Deploy to devnet
-anchor deploy --provider.cluster devnet
+yarn deploy:devnet
 ```
+
+### Notes
+
+- The default runnable path uses `cargo build-sbf` and `solana program deploy`, which avoids Anchor CLI/toolchain mismatches on machines where `anchor build` is not wired to the installed Solana platform tools.
+- `yarn build:program` performs a preflight check and will ask you to upgrade Solana platform-tools if your local `cargo build-sbf` is too old for this dependency set.
+- The checked-in program id is synced to `target/deploy/solana_guard-keypair.json`. If you regenerate the keypair, run `yarn keys:sync` before building or deploying.
+- The LiteSVM integration tests are opt-in behind the `sbf-tests` feature because they require a fresh SBF artifact and a tightly matched Solana test-toolchain stack.
 
 ## Tech Stack
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "license": "ISC",
   "scripts": {
+    "build:program": "./scripts/build-program",
+    "test:host": "cargo test",
+    "deploy:devnet": "solana program deploy target/deploy/solana_guard.so --program-id target/deploy/solana_guard-keypair.json --url devnet",
+    "keys:sync": "./scripts/anchorw keys sync",
     "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
     "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
   },
   "dependencies": {
-    "@anchor-lang/core": "^1.0.0"
+    "@anchor-lang/core": "0.32.1"
   },
   "devDependencies": {
     "chai": "^4.3.4",

--- a/programs/solana-guard/Cargo.toml
+++ b/programs/solana-guard/Cargo.toml
@@ -5,7 +5,7 @@ description = "Created with Anchor"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["cdylib", "rlib"]
 name = "solana_guard"
 
 [features]
@@ -18,18 +18,11 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-debug = []
 custom-heap = []
 custom-panic = []
+sbf-tests = []
 
 
 [dependencies]
-anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
-
-[dev-dependencies]
-litesvm = "0.10.0"
-solana-message = "3.0.1"
-solana-transaction = "3.0.2"
-solana-signer = "3.0.0"
-solana-keypair = "3.0.1"
-
+anchor-lang = { version = "0.32.1", features = ["init-if-needed"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }

--- a/programs/solana-guard/src/constants.rs
+++ b/programs/solana-guard/src/constants.rs
@@ -5,13 +5,18 @@ pub const AGENT_SEED: &[u8] = b"agent";
 pub const POLICY_SEED: &[u8] = b"policy";
 pub const TX_LOG_SEED: &[u8] = b"tx_log";
 pub const NONCE_SEED: &[u8] = b"nonce";
+pub const VAULT_SEED: &[u8] = b"vault";
 
 /// Time constants
 pub const SECONDS_PER_DAY: i64 = 86_400;
 
 /// Rejection reason codes emitted in TransactionRejected events
+pub const REJECTION_NONE: u8 = 0;
 pub const REJECTION_AGENT_NOT_ACTIVE: u8 = 1;
 pub const REJECTION_POLICY_NOT_ACTIVE: u8 = 2;
 pub const REJECTION_EXCEEDS_PER_TX_LIMIT: u8 = 3;
 pub const REJECTION_EXCEEDS_DAILY_LIMIT: u8 = 4;
 pub const REJECTION_PROTOCOL_NOT_ALLOWED: u8 = 5;
+pub const REJECTION_EXCEEDS_TX_LIMIT: u8 = 6;
+pub const REJECTION_EXCEEDS_SLIPPAGE_LIMIT: u8 = 7;
+pub const REJECTION_INSUFFICIENT_VAULT_BALANCE: u8 = 8;

--- a/programs/solana-guard/src/constants.rs
+++ b/programs/solana-guard/src/constants.rs
@@ -1,5 +1,3 @@
-use anchor_lang::prelude::*;
-
 /// PDA seeds
 pub const AGENT_SEED: &[u8] = b"agent";
 pub const POLICY_SEED: &[u8] = b"policy";

--- a/programs/solana-guard/src/constants.rs
+++ b/programs/solana-guard/src/constants.rs
@@ -8,3 +8,10 @@ pub const NONCE_SEED: &[u8] = b"nonce";
 
 /// Time constants
 pub const SECONDS_PER_DAY: i64 = 86_400;
+
+/// Rejection reason codes emitted in TransactionRejected events
+pub const REJECTION_AGENT_NOT_ACTIVE: u8 = 1;
+pub const REJECTION_POLICY_NOT_ACTIVE: u8 = 2;
+pub const REJECTION_EXCEEDS_PER_TX_LIMIT: u8 = 3;
+pub const REJECTION_EXCEEDS_DAILY_LIMIT: u8 = 4;
+pub const REJECTION_PROTOCOL_NOT_ALLOWED: u8 = 5;

--- a/programs/solana-guard/src/error.rs
+++ b/programs/solana-guard/src/error.rs
@@ -14,8 +14,17 @@ pub enum SolanaGuardError {
     #[msg("Transaction would exceed daily spending limit")]
     ExceedsDailyLimit,
 
+    #[msg("Transaction would exceed the daily transaction count limit")]
+    ExceedsTxLimit,
+
     #[msg("Target protocol is not in the allowed list")]
     ProtocolNotAllowed,
+
+    #[msg("Observed slippage exceeds the configured slippage limit")]
+    ExceedsSlippageLimit,
+
+    #[msg("Vault balance is insufficient for this transfer")]
+    InsufficientVaultBalance,
 
     #[msg("Only the owner can perform this action")]
     UnauthorizedOwner,
@@ -34,4 +43,7 @@ pub enum SolanaGuardError {
 
     #[msg("Daily limit must be greater than or equal to per-transaction limit")]
     InvalidDailyLimit,
+
+    #[msg("Daily transaction limit must be greater than zero")]
+    InvalidTxLimit,
 }

--- a/programs/solana-guard/src/instructions.rs
+++ b/programs/solana-guard/src/instructions.rs
@@ -1,12 +1,18 @@
+#![allow(ambiguous_glob_reexports)]
+
+pub mod fund_vault;
 pub mod register_agent;
 pub mod set_policy;
-pub mod validate_and_execute;
 pub mod toggle_agent;
 pub mod update_policy;
+pub mod validate_and_execute;
+pub mod withdraw_vault;
 
 // Re-export everything — Anchor's #[program] macro needs full crate-level access
+pub use fund_vault::*;
 pub use register_agent::*;
 pub use set_policy::*;
-pub use validate_and_execute::*;
 pub use toggle_agent::*;
 pub use update_policy::*;
+pub use validate_and_execute::*;
+pub use withdraw_vault::*;

--- a/programs/solana-guard/src/instructions/fund_vault.rs
+++ b/programs/solana-guard/src/instructions/fund_vault.rs
@@ -8,7 +8,7 @@ pub fn handler(ctx: Context<FundVault>, amount: u64) -> Result<()> {
         from: ctx.accounts.owner.to_account_info(),
         to: ctx.accounts.vault.to_account_info(),
     };
-    let cpi_ctx = CpiContext::new(ctx.accounts.system_program.key(), cpi_accounts);
+    let cpi_ctx = CpiContext::new(ctx.accounts.system_program.to_account_info(), cpi_accounts);
     system_program::transfer(cpi_ctx, amount)?;
 
     msg!(

--- a/programs/solana-guard/src/instructions/fund_vault.rs
+++ b/programs/solana-guard/src/instructions/fund_vault.rs
@@ -1,0 +1,44 @@
+use crate::constants::*;
+use crate::state::*;
+use anchor_lang::prelude::*;
+use anchor_lang::system_program;
+
+pub fn handler(ctx: Context<FundVault>, amount: u64) -> Result<()> {
+    let cpi_accounts = system_program::Transfer {
+        from: ctx.accounts.owner.to_account_info(),
+        to: ctx.accounts.vault.to_account_info(),
+    };
+    let cpi_ctx = CpiContext::new(ctx.accounts.system_program.key(), cpi_accounts);
+    system_program::transfer(cpi_ctx, amount)?;
+
+    msg!(
+        "SolanaGuard: Vault funded for agent {} with {} lamports",
+        ctx.accounts.agent_config.agent,
+        amount
+    );
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct FundVault<'info> {
+    #[account(mut)]
+    pub owner: Signer<'info>,
+
+    #[account(
+        seeds = [AGENT_SEED, owner.key().as_ref(), agent_config.agent.as_ref()],
+        bump = agent_config.bump,
+        has_one = owner,
+    )]
+    pub agent_config: Account<'info, AgentConfig>,
+
+    #[account(
+        mut,
+        seeds = [VAULT_SEED, owner.key().as_ref(), agent_config.agent.as_ref()],
+        bump = vault.bump,
+        has_one = owner,
+    )]
+    pub vault: Account<'info, Vault>,
+
+    pub system_program: Program<'info, System>,
+}

--- a/programs/solana-guard/src/instructions/register_agent.rs
+++ b/programs/solana-guard/src/instructions/register_agent.rs
@@ -1,12 +1,13 @@
-use anchor_lang::prelude::*;
-use crate::state::*;
 use crate::constants::*;
+use crate::state::*;
+use anchor_lang::prelude::*;
 
 /// Registers a new AI agent under the caller's ownership.
 /// Creates an AgentConfig PDA and an AgentNonce tracker.
 pub fn handler(ctx: Context<RegisterAgent>) -> Result<()> {
     let agent_config = &mut ctx.accounts.agent_config;
     let agent_nonce = &mut ctx.accounts.agent_nonce;
+    let vault = &mut ctx.accounts.vault;
     let clock = Clock::get()?;
 
     agent_config.owner = ctx.accounts.owner.key();
@@ -20,10 +21,15 @@ pub fn handler(ctx: Context<RegisterAgent>) -> Result<()> {
     agent_nonce.nonce = 0;
     agent_nonce.bump = ctx.bumps.agent_nonce;
 
+    vault.owner = ctx.accounts.owner.key();
+    vault.agent = ctx.accounts.agent.key();
+    vault.bump = ctx.bumps.vault;
+
     msg!(
-        "SolanaGuard: Agent {} registered by owner {}",
+        "SolanaGuard: Agent {} registered by owner {} with guarded vault {}",
         ctx.accounts.agent.key(),
-        ctx.accounts.owner.key()
+        ctx.accounts.owner.key(),
+        ctx.accounts.vault.key()
     );
 
     Ok(())
@@ -58,6 +64,16 @@ pub struct RegisterAgent<'info> {
         bump,
     )]
     pub agent_nonce: Account<'info, AgentNonce>,
+
+    /// PDA storing funds that can only be spent through guardrail checks
+    #[account(
+        init,
+        payer = owner,
+        space = 8 + Vault::INIT_SPACE,
+        seeds = [VAULT_SEED, owner.key().as_ref(), agent.key().as_ref()],
+        bump,
+    )]
+    pub vault: Account<'info, Vault>,
 
     pub system_program: Program<'info, System>,
 }

--- a/programs/solana-guard/src/instructions/set_policy.rs
+++ b/programs/solana-guard/src/instructions/set_policy.rs
@@ -1,7 +1,7 @@
-use anchor_lang::prelude::*;
-use crate::state::*;
-use crate::error::SolanaGuardError;
 use crate::constants::*;
+use crate::error::SolanaGuardError;
+use crate::state::*;
+use anchor_lang::prelude::*;
 
 /// Sets or updates the risk policy for a registered agent.
 /// Only the owner can set policies for their agents.
@@ -9,11 +9,17 @@ pub fn handler(
     ctx: Context<SetPolicy>,
     max_spend_per_tx: u64,
     daily_limit: u64,
+    max_tx_per_day: u64,
     allowed_protocols: Vec<Pubkey>,
+    slippage_bps: u16,
 ) -> Result<()> {
     // Validate inputs
     require!(max_spend_per_tx > 0, SolanaGuardError::InvalidSpendingLimit);
-    require!(daily_limit >= max_spend_per_tx, SolanaGuardError::InvalidDailyLimit);
+    require!(
+        daily_limit >= max_spend_per_tx,
+        SolanaGuardError::InvalidDailyLimit
+    );
+    require!(max_tx_per_day > 0, SolanaGuardError::InvalidTxLimit);
     require!(
         allowed_protocols.len() <= MAX_ALLOWED_PROTOCOLS,
         SolanaGuardError::TooManyProtocols
@@ -26,17 +32,22 @@ pub fn handler(
     policy.agent = ctx.accounts.agent_config.agent;
     policy.max_spend_per_tx = max_spend_per_tx;
     policy.daily_limit = daily_limit;
+    policy.max_tx_per_day = max_tx_per_day;
     policy.daily_spent = 0;
+    policy.tx_count_today = 0;
     policy.day_start = clock.unix_timestamp;
+    policy.slippage_bps = slippage_bps;
     policy.is_active = true;
     policy.allowed_protocols = allowed_protocols;
     policy.bump = ctx.bumps.policy;
 
     msg!(
-        "SolanaGuard: Policy set for agent {} — max/tx: {} lamports, daily: {} lamports",
+        "SolanaGuard: Policy set for agent {} — max/tx: {} lamports, daily: {} lamports, tx/day: {}, slippage: {} bps",
         policy.agent,
         max_spend_per_tx,
-        daily_limit
+        daily_limit,
+        max_tx_per_day,
+        slippage_bps
     );
 
     Ok(())

--- a/programs/solana-guard/src/instructions/toggle_agent.rs
+++ b/programs/solana-guard/src/instructions/toggle_agent.rs
@@ -1,7 +1,7 @@
-use anchor_lang::prelude::*;
-use crate::state::*;
-use crate::error::SolanaGuardError;
 use crate::constants::*;
+use crate::error::SolanaGuardError;
+use crate::state::*;
+use anchor_lang::prelude::*;
 
 /// Toggles an agent's active status (pause/unpause).
 /// Only the owner can call this.

--- a/programs/solana-guard/src/instructions/update_policy.rs
+++ b/programs/solana-guard/src/instructions/update_policy.rs
@@ -1,7 +1,7 @@
-use anchor_lang::prelude::*;
-use crate::state::*;
-use crate::error::SolanaGuardError;
 use crate::constants::*;
+use crate::error::SolanaGuardError;
+use crate::state::*;
+use anchor_lang::prelude::*;
 
 /// Updates an existing policy's limits and allowed protocols.
 /// Only the owner can update their agent's policy.
@@ -9,12 +9,15 @@ pub fn handler(
     ctx: Context<UpdatePolicy>,
     max_spend_per_tx: Option<u64>,
     daily_limit: Option<u64>,
+    max_tx_per_day: Option<u64>,
     allowed_protocols: Option<Vec<Pubkey>>,
+    slippage_bps: Option<u16>,
     is_active: Option<bool>,
 ) -> Result<()> {
     let policy = &mut ctx.accounts.policy;
     let new_max_spend_per_tx = max_spend_per_tx.unwrap_or(policy.max_spend_per_tx);
     let new_daily_limit = daily_limit.unwrap_or(policy.daily_limit);
+    let new_max_tx_per_day = max_tx_per_day.unwrap_or(policy.max_tx_per_day);
 
     require!(
         new_max_spend_per_tx > 0,
@@ -24,9 +27,11 @@ pub fn handler(
         new_daily_limit >= new_max_spend_per_tx,
         SolanaGuardError::InvalidDailyLimit
     );
+    require!(new_max_tx_per_day > 0, SolanaGuardError::InvalidTxLimit);
 
     policy.max_spend_per_tx = new_max_spend_per_tx;
     policy.daily_limit = new_daily_limit;
+    policy.max_tx_per_day = new_max_tx_per_day;
 
     if let Some(protocols) = allowed_protocols {
         require!(
@@ -36,15 +41,21 @@ pub fn handler(
         policy.allowed_protocols = protocols;
     }
 
+    if let Some(slippage_bps) = slippage_bps {
+        policy.slippage_bps = slippage_bps;
+    }
+
     if let Some(active) = is_active {
         policy.is_active = active;
     }
 
     msg!(
-        "SolanaGuard: Policy updated for agent {} — max/tx: {}, daily: {}, active: {}",
+        "SolanaGuard: Policy updated for agent {} — max/tx: {}, daily: {}, tx/day: {}, slippage: {} bps, active: {}",
         policy.agent,
         policy.max_spend_per_tx,
         policy.daily_limit,
+        policy.max_tx_per_day,
+        policy.slippage_bps,
         policy.is_active
     );
 

--- a/programs/solana-guard/src/instructions/validate_and_execute.rs
+++ b/programs/solana-guard/src/instructions/validate_and_execute.rs
@@ -23,39 +23,91 @@ pub fn handler(
     let tx_log = &mut ctx.accounts.tx_log;
     let agent_nonce = &mut ctx.accounts.agent_nonce;
     let clock = Clock::get()?;
+    let now = clock.unix_timestamp;
 
     // ---- Check 1: Agent must be active ----
-    require!(agent_config.is_active, SolanaGuardError::AgentNotActive);
+    if !agent_config.is_active {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            policy.daily_spent,
+            now,
+            REJECTION_AGENT_NOT_ACTIVE,
+        );
+        return err!(SolanaGuardError::AgentNotActive);
+    }
 
     // ---- Check 2: Policy must be active ----
-    require!(policy.is_active, SolanaGuardError::PolicyNotActive);
+    if !policy.is_active {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            policy.daily_spent,
+            now,
+            REJECTION_POLICY_NOT_ACTIVE,
+        );
+        return err!(SolanaGuardError::PolicyNotActive);
+    }
 
     // ---- Check 3: Per-transaction limit ----
-    require!(
-        amount <= policy.max_spend_per_tx,
-        SolanaGuardError::ExceedsPerTxLimit
-    );
+    if amount > policy.max_spend_per_tx {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            policy.daily_spent,
+            now,
+            REJECTION_EXCEEDS_PER_TX_LIMIT,
+        );
+        return err!(SolanaGuardError::ExceedsPerTxLimit);
+    }
 
     // ---- Check 4: Daily limit (with 24h reset) ----
-    let now = clock.unix_timestamp;
-    if now - policy.day_start >= SECONDS_PER_DAY {
+    let should_reset_day = now - policy.day_start >= SECONDS_PER_DAY;
+    let current_daily_spent = if should_reset_day {
+        0
+    } else {
+        policy.daily_spent
+    };
+
+    if current_daily_spent.checked_add(amount).unwrap_or(u64::MAX) > policy.daily_limit {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            current_daily_spent,
+            now,
+            REJECTION_EXCEEDS_DAILY_LIMIT,
+        );
+        return err!(SolanaGuardError::ExceedsDailyLimit);
+    }
+
+    // ---- Check 5: Protocol allowlist ----
+    if !policy.allowed_protocols.contains(&target_protocol) {
+        emit_rejection(
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            current_daily_spent,
+            now,
+            REJECTION_PROTOCOL_NOT_ALLOWED,
+        );
+        return err!(SolanaGuardError::ProtocolNotAllowed);
+    }
+
+    // ---- All checks passed — update state ----
+    if should_reset_day {
         // Reset the daily counter — new day
         policy.daily_spent = 0;
         policy.day_start = now;
     }
-
-    require!(
-        policy.daily_spent.checked_add(amount).unwrap_or(u64::MAX) <= policy.daily_limit,
-        SolanaGuardError::ExceedsDailyLimit
-    );
-
-    // ---- Check 5: Protocol allowlist ----
-    require!(
-        policy.allowed_protocols.contains(&target_protocol),
-        SolanaGuardError::ProtocolNotAllowed
-    );
-
-    // ---- All checks passed — update state ----
     policy.daily_spent = policy.daily_spent.checked_add(amount).unwrap();
 
     // Write transaction log
@@ -81,6 +133,27 @@ pub fn handler(
     );
 
     Ok(())
+}
+
+fn emit_rejection(
+    agent_config: &AgentConfig,
+    policy: &Policy,
+    amount: u64,
+    target_protocol: Pubkey,
+    daily_spent: u64,
+    rejected_at: i64,
+    reason_code: u8,
+) {
+    emit!(TransactionRejected {
+        agent: agent_config.agent,
+        owner: agent_config.owner,
+        amount,
+        target_protocol,
+        daily_spent,
+        daily_limit: policy.daily_limit,
+        rejected_at,
+        reason_code,
+    });
 }
 
 #[derive(Accounts)]

--- a/programs/solana-guard/src/instructions/validate_and_execute.rs
+++ b/programs/solana-guard/src/instructions/validate_and_execute.rs
@@ -1,10 +1,10 @@
-use anchor_lang::prelude::*;
-use crate::state::*;
-use crate::error::SolanaGuardError;
 use crate::constants::*;
+use crate::error::SolanaGuardError;
+use crate::state::*;
+use anchor_lang::prelude::*;
 
 /// Validates a transaction against the agent's policy, then executes it.
-/// This is the core guardrail enforcement — every agent transaction must 
+/// This is the core guardrail enforcement — every agent transaction must
 /// pass through this instruction.
 ///
 /// Checks enforced:
@@ -17,54 +17,71 @@ pub fn handler(
     ctx: Context<ValidateAndExecute>,
     amount: u64,
     target_protocol: Pubkey,
+    observed_slippage_bps: u16,
 ) -> Result<()> {
     let agent_config = &ctx.accounts.agent_config;
     let policy = &mut ctx.accounts.policy;
     let tx_log = &mut ctx.accounts.tx_log;
     let agent_nonce = &mut ctx.accounts.agent_nonce;
+    let vault = &ctx.accounts.vault;
     let clock = Clock::get()?;
     let now = clock.unix_timestamp;
 
     // ---- Check 1: Agent must be active ----
     if !agent_config.is_active {
-        emit_rejection(
+        record_rejection(
+            tx_log,
+            agent_nonce,
             agent_config,
             policy,
             amount,
             target_protocol,
+            observed_slippage_bps,
             policy.daily_spent,
+            policy.tx_count_today,
             now,
             REJECTION_AGENT_NOT_ACTIVE,
+            ctx.bumps.tx_log,
         );
-        return err!(SolanaGuardError::AgentNotActive);
+        return Ok(());
     }
 
     // ---- Check 2: Policy must be active ----
     if !policy.is_active {
-        emit_rejection(
+        record_rejection(
+            tx_log,
+            agent_nonce,
             agent_config,
             policy,
             amount,
             target_protocol,
+            observed_slippage_bps,
             policy.daily_spent,
+            policy.tx_count_today,
             now,
             REJECTION_POLICY_NOT_ACTIVE,
+            ctx.bumps.tx_log,
         );
-        return err!(SolanaGuardError::PolicyNotActive);
+        return Ok(());
     }
 
     // ---- Check 3: Per-transaction limit ----
     if amount > policy.max_spend_per_tx {
-        emit_rejection(
+        record_rejection(
+            tx_log,
+            agent_nonce,
             agent_config,
             policy,
             amount,
             target_protocol,
+            observed_slippage_bps,
             policy.daily_spent,
+            policy.tx_count_today,
             now,
             REJECTION_EXCEEDS_PER_TX_LIMIT,
+            ctx.bumps.tx_log,
         );
-        return err!(SolanaGuardError::ExceedsPerTxLimit);
+        return Ok(());
     }
 
     // ---- Check 4: Daily limit (with 24h reset) ----
@@ -74,49 +91,131 @@ pub fn handler(
     } else {
         policy.daily_spent
     };
+    let current_tx_count = if should_reset_day {
+        0
+    } else {
+        policy.tx_count_today
+    };
 
     if current_daily_spent.checked_add(amount).unwrap_or(u64::MAX) > policy.daily_limit {
-        emit_rejection(
+        record_rejection(
+            tx_log,
+            agent_nonce,
             agent_config,
             policy,
             amount,
             target_protocol,
+            observed_slippage_bps,
             current_daily_spent,
+            current_tx_count,
             now,
             REJECTION_EXCEEDS_DAILY_LIMIT,
+            ctx.bumps.tx_log,
         );
-        return err!(SolanaGuardError::ExceedsDailyLimit);
+        return Ok(());
     }
 
-    // ---- Check 5: Protocol allowlist ----
-    if !policy.allowed_protocols.contains(&target_protocol) {
-        emit_rejection(
+    // ---- Check 5: Daily transaction count ----
+    if current_tx_count.checked_add(1).unwrap_or(u64::MAX) > policy.max_tx_per_day {
+        record_rejection(
+            tx_log,
+            agent_nonce,
             agent_config,
             policy,
             amount,
             target_protocol,
+            observed_slippage_bps,
             current_daily_spent,
+            current_tx_count,
             now,
-            REJECTION_PROTOCOL_NOT_ALLOWED,
+            REJECTION_EXCEEDS_TX_LIMIT,
+            ctx.bumps.tx_log,
         );
-        return err!(SolanaGuardError::ProtocolNotAllowed);
+        return Ok(());
     }
 
-    // ---- All checks passed — update state ----
+    // ---- Check 6: Protocol allowlist ----
+    if !policy.allowed_protocols.contains(&target_protocol) {
+        record_rejection(
+            tx_log,
+            agent_nonce,
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            observed_slippage_bps,
+            current_daily_spent,
+            current_tx_count,
+            now,
+            REJECTION_PROTOCOL_NOT_ALLOWED,
+            ctx.bumps.tx_log,
+        );
+        return Ok(());
+    }
+
+    // ---- Check 7: Slippage guard ----
+    if observed_slippage_bps > policy.slippage_bps {
+        record_rejection(
+            tx_log,
+            agent_nonce,
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            observed_slippage_bps,
+            current_daily_spent,
+            current_tx_count,
+            now,
+            REJECTION_EXCEEDS_SLIPPAGE_LIMIT,
+            ctx.bumps.tx_log,
+        );
+        return Ok(());
+    }
+
+    // ---- Check 8: Vault must hold the guarded funds ----
+    if vault.to_account_info().lamports() < amount {
+        record_rejection(
+            tx_log,
+            agent_nonce,
+            agent_config,
+            policy,
+            amount,
+            target_protocol,
+            observed_slippage_bps,
+            current_daily_spent,
+            current_tx_count,
+            now,
+            REJECTION_INSUFFICIENT_VAULT_BALANCE,
+            ctx.bumps.tx_log,
+        );
+        return Ok(());
+    }
+
+    // ---- All checks passed — execute the guarded transfer ----
+    let vault_info = vault.to_account_info();
+    let recipient_info = ctx.accounts.recipient.to_account_info();
+    **vault_info.try_borrow_mut_lamports()? -= amount;
+    **recipient_info.try_borrow_mut_lamports()? += amount;
+
+    // ---- Update state after the transfer succeeds ----
     if should_reset_day {
         // Reset the daily counter — new day
         policy.daily_spent = 0;
+        policy.tx_count_today = 0;
         policy.day_start = now;
     }
     policy.daily_spent = policy.daily_spent.checked_add(amount).unwrap();
+    policy.tx_count_today = policy.tx_count_today.checked_add(1).unwrap();
 
     // Write transaction log
     tx_log.agent = agent_config.agent;
     tx_log.owner = agent_config.owner;
     tx_log.amount = amount;
+    tx_log.slippage_bps = observed_slippage_bps;
     tx_log.target_protocol = target_protocol;
     tx_log.executed_at = now;
     tx_log.was_approved = true;
+    tx_log.reason_code = REJECTION_NONE;
     tx_log.nonce = agent_nonce.nonce;
     tx_log.bump = ctx.bumps.tx_log;
 
@@ -124,39 +223,73 @@ pub fn handler(
     agent_nonce.nonce = agent_nonce.nonce.checked_add(1).unwrap();
 
     msg!(
-        "SolanaGuard: ✅ APPROVED — Agent {} spent {} lamports on protocol {}. Daily total: {}/{}",
+        "SolanaGuard: ✅ APPROVED — Agent {} spent {} lamports from vault {} to {}. Daily total: {}/{}, tx count: {}/{}, slippage: {}/{} bps",
         agent_config.agent,
         amount,
-        target_protocol,
+        vault.key(),
+        ctx.accounts.recipient.key(),
         policy.daily_spent,
-        policy.daily_limit
+        policy.daily_limit,
+        policy.tx_count_today,
+        policy.max_tx_per_day,
+        observed_slippage_bps,
+        policy.slippage_bps
     );
 
     Ok(())
 }
 
-fn emit_rejection(
+fn record_rejection(
+    tx_log: &mut Account<TransactionLog>,
+    agent_nonce: &mut Account<AgentNonce>,
     agent_config: &AgentConfig,
     policy: &Policy,
     amount: u64,
     target_protocol: Pubkey,
+    slippage_bps: u16,
     daily_spent: u64,
+    tx_count_today: u64,
     rejected_at: i64,
     reason_code: u8,
+    tx_log_bump: u8,
 ) {
+    tx_log.agent = agent_config.agent;
+    tx_log.owner = agent_config.owner;
+    tx_log.amount = amount;
+    tx_log.slippage_bps = slippage_bps;
+    tx_log.target_protocol = target_protocol;
+    tx_log.executed_at = rejected_at;
+    tx_log.was_approved = false;
+    tx_log.reason_code = reason_code;
+    tx_log.nonce = agent_nonce.nonce;
+    tx_log.bump = tx_log_bump;
+
+    agent_nonce.nonce = agent_nonce.nonce.checked_add(1).unwrap();
+
     emit!(TransactionRejected {
         agent: agent_config.agent,
         owner: agent_config.owner,
         amount,
+        slippage_bps,
         target_protocol,
         daily_spent,
+        tx_count_today,
         daily_limit: policy.daily_limit,
         rejected_at,
         reason_code,
     });
+
+    msg!(
+        "SolanaGuard: REJECTED — Agent {} attempted {} lamports to {} with reason code {}",
+        agent_config.agent,
+        amount,
+        target_protocol,
+        reason_code
+    );
 }
 
 #[derive(Accounts)]
+#[instruction(amount: u64, target_protocol: Pubkey, observed_slippage_bps: u16)]
 pub struct ValidateAndExecute<'info> {
     /// The agent executing the transaction (must be the registered agent)
     #[account(mut)]
@@ -181,6 +314,20 @@ pub struct ValidateAndExecute<'info> {
         bump = policy.bump,
     )]
     pub policy: Account<'info, Policy>,
+
+    /// Program-controlled vault holding the funds subject to guardrails
+    #[account(
+        mut,
+        seeds = [VAULT_SEED, owner.key().as_ref(), agent.key().as_ref()],
+        bump = vault.bump,
+        has_one = owner @ SolanaGuardError::UnauthorizedOwner,
+        has_one = agent @ SolanaGuardError::UnauthorizedAgent,
+    )]
+    pub vault: Account<'info, Vault>,
+
+    /// CHECK: Recipient of the guarded transfer. The key must match the allowlisted target.
+    #[account(mut, address = target_protocol)]
+    pub recipient: UncheckedAccount<'info>,
 
     /// Transaction log entry (created per transaction)
     #[account(

--- a/programs/solana-guard/src/instructions/withdraw_vault.rs
+++ b/programs/solana-guard/src/instructions/withdraw_vault.rs
@@ -1,0 +1,47 @@
+use crate::constants::*;
+use crate::error::SolanaGuardError;
+use crate::state::*;
+use anchor_lang::prelude::*;
+
+pub fn handler(ctx: Context<WithdrawVault>, amount: u64) -> Result<()> {
+    let vault_info = ctx.accounts.vault.to_account_info();
+    let owner_info = ctx.accounts.owner.to_account_info();
+
+    require!(
+        vault_info.lamports() >= amount,
+        SolanaGuardError::InsufficientVaultBalance
+    );
+
+    **vault_info.try_borrow_mut_lamports()? -= amount;
+    **owner_info.try_borrow_mut_lamports()? += amount;
+
+    msg!(
+        "SolanaGuard: Owner {} withdrew {} lamports from vault for agent {}",
+        ctx.accounts.owner.key(),
+        amount,
+        ctx.accounts.agent_config.agent
+    );
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct WithdrawVault<'info> {
+    #[account(mut)]
+    pub owner: Signer<'info>,
+
+    #[account(
+        seeds = [AGENT_SEED, owner.key().as_ref(), agent_config.agent.as_ref()],
+        bump = agent_config.bump,
+        has_one = owner,
+    )]
+    pub agent_config: Account<'info, AgentConfig>,
+
+    #[account(
+        mut,
+        seeds = [VAULT_SEED, owner.key().as_ref(), agent_config.agent.as_ref()],
+        bump = vault.bump,
+        has_one = owner,
+    )]
+    pub vault: Account<'info, Vault>,
+}

--- a/programs/solana-guard/src/lib.rs
+++ b/programs/solana-guard/src/lib.rs
@@ -9,7 +9,7 @@ pub use constants::*;
 pub use instructions::*;
 pub use state::*;
 
-declare_id!("FRuK1VzhqjybBMhp8UGVipJ9jkyuT9Dy7YJHAREwSApw");
+declare_id!("5Tk7LXUpzRTWsDLXRiUUirJVv3Jne53F2DTq7xAqMey");
 
 #[program]
 pub mod solana_guard {

--- a/programs/solana-guard/src/lib.rs
+++ b/programs/solana-guard/src/lib.rs
@@ -16,9 +16,14 @@ pub mod solana_guard {
     use super::*;
 
     /// Register a new AI agent under the caller's ownership.
-    /// Creates an AgentConfig PDA bound to the owner+agent pair.
+    /// Creates an AgentConfig PDA bound to the owner+agent pair and a vault PDA.
     pub fn register_agent(ctx: Context<RegisterAgent>) -> Result<()> {
         instructions::register_agent::handler(ctx)
+    }
+
+    /// Fund the program-controlled vault for a registered agent.
+    pub fn fund_vault(ctx: Context<FundVault>, amount: u64) -> Result<()> {
+        instructions::fund_vault::handler(ctx, amount)
     }
 
     /// Set the risk policy for a registered agent.
@@ -27,9 +32,18 @@ pub mod solana_guard {
         ctx: Context<SetPolicy>,
         max_spend_per_tx: u64,
         daily_limit: u64,
+        max_tx_per_day: u64,
         allowed_protocols: Vec<Pubkey>,
+        slippage_bps: u16,
     ) -> Result<()> {
-        instructions::set_policy::handler(ctx, max_spend_per_tx, daily_limit, allowed_protocols)
+        instructions::set_policy::handler(
+            ctx,
+            max_spend_per_tx,
+            daily_limit,
+            max_tx_per_day,
+            allowed_protocols,
+            slippage_bps,
+        )
     }
 
     /// Validate a transaction against the agent's policy and log it.
@@ -38,8 +52,14 @@ pub mod solana_guard {
         ctx: Context<ValidateAndExecute>,
         amount: u64,
         target_protocol: Pubkey,
+        observed_slippage_bps: u16,
     ) -> Result<()> {
-        instructions::validate_and_execute::handler(ctx, amount, target_protocol)
+        instructions::validate_and_execute::handler(
+            ctx,
+            amount,
+            target_protocol,
+            observed_slippage_bps,
+        )
     }
 
     /// Toggle agent active status (emergency kill switch).
@@ -48,20 +68,29 @@ pub mod solana_guard {
         instructions::toggle_agent::handler(ctx, is_active)
     }
 
+    /// Withdraw SOL from the vault back to the owner.
+    pub fn withdraw_vault(ctx: Context<WithdrawVault>, amount: u64) -> Result<()> {
+        instructions::withdraw_vault::handler(ctx, amount)
+    }
+
     /// Update an existing policy's parameters.
     /// Supports partial updates — only provided fields are changed.
     pub fn update_policy(
         ctx: Context<UpdatePolicy>,
         max_spend_per_tx: Option<u64>,
         daily_limit: Option<u64>,
+        max_tx_per_day: Option<u64>,
         allowed_protocols: Option<Vec<Pubkey>>,
+        slippage_bps: Option<u16>,
         is_active: Option<bool>,
     ) -> Result<()> {
         instructions::update_policy::handler(
             ctx,
             max_spend_per_tx,
             daily_limit,
+            max_tx_per_day,
             allowed_protocols,
+            slippage_bps,
             is_active,
         )
     }

--- a/programs/solana-guard/src/state.rs
+++ b/programs/solana-guard/src/state.rs
@@ -31,10 +31,16 @@ pub struct Policy {
     pub max_spend_per_tx: u64,
     /// Maximum SOL (in lamports) the agent can spend per day
     pub daily_limit: u64,
+    /// Maximum number of approved transactions per day
+    pub max_tx_per_day: u64,
     /// Running total of SOL spent in the current day
     pub daily_spent: u64,
+    /// Number of approved transactions in the current day
+    pub tx_count_today: u64,
     /// Unix timestamp of the current spending day (resets every 24h)
     pub day_start: i64,
+    /// Maximum permitted slippage in basis points
+    pub slippage_bps: u16,
     /// Whether the policy is active (owner can pause)
     pub is_active: bool,
     /// List of program IDs the agent is allowed to interact with
@@ -54,12 +60,16 @@ pub struct TransactionLog {
     pub owner: Pubkey,
     /// Amount in lamports
     pub amount: u64,
+    /// Slippage reported for this attempted action, in basis points
+    pub slippage_bps: u16,
     /// The target program the agent interacted with
     pub target_protocol: Pubkey,
     /// Timestamp of execution
     pub executed_at: i64,
     /// Whether the transaction was approved or rejected
     pub was_approved: bool,
+    /// Machine-readable reason code. Zero means approved.
+    pub reason_code: u8,
     /// Sequential nonce for uniqueness
     pub nonce: u64,
     /// Bump seed
@@ -77,10 +87,14 @@ pub struct TransactionRejected {
     pub owner: Pubkey,
     /// Requested amount in lamports
     pub amount: u64,
+    /// Slippage reported for the attempted action, in basis points
+    pub slippage_bps: u16,
     /// The target program the agent attempted to interact with
     pub target_protocol: Pubkey,
     /// Running daily spend used for the validation
     pub daily_spent: u64,
+    /// Running transaction count used for the validation
+    pub tx_count_today: u64,
     /// Configured daily limit
     pub daily_limit: u64,
     /// Timestamp of rejection
@@ -96,5 +110,17 @@ pub struct AgentNonce {
     pub owner: Pubkey,
     pub agent: Pubkey,
     pub nonce: u64,
+    pub bump: u8,
+}
+
+/// Program-controlled SOL vault used for deterministic guarded execution
+#[account]
+#[derive(InitSpace)]
+pub struct Vault {
+    /// Owner that can fund or withdraw this vault
+    pub owner: Pubkey,
+    /// Agent authorized to spend through guardrails
+    pub agent: Pubkey,
+    /// PDA bump
     pub bump: u8,
 }

--- a/programs/solana-guard/src/state.rs
+++ b/programs/solana-guard/src/state.rs
@@ -66,6 +66,29 @@ pub struct TransactionLog {
     pub bump: u8,
 }
 
+/// Event emitted when a transaction attempt is rejected.
+/// Failed instructions cannot persist TransactionLog accounts, so rejected
+/// attempts are exposed through transaction logs instead.
+#[event]
+pub struct TransactionRejected {
+    /// The agent that attempted this transaction
+    pub agent: Pubkey,
+    /// The owner of the agent
+    pub owner: Pubkey,
+    /// Requested amount in lamports
+    pub amount: u64,
+    /// The target program the agent attempted to interact with
+    pub target_protocol: Pubkey,
+    /// Running daily spend used for the validation
+    pub daily_spent: u64,
+    /// Configured daily limit
+    pub daily_limit: u64,
+    /// Timestamp of rejection
+    pub rejected_at: i64,
+    /// Machine-readable reason code. See constants.rs.
+    pub reason_code: u8,
+}
+
 /// Global nonce tracker per agent for transaction log indexing
 #[account]
 #[derive(InitSpace)]

--- a/programs/solana-guard/tests/test_initialize.rs
+++ b/programs/solana-guard/tests/test_initialize.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "sbf-tests")]
+
 use {
     anchor_lang::{
         solana_program::instruction::Instruction, solana_program::pubkey::Pubkey,

--- a/programs/solana-guard/tests/test_initialize.rs
+++ b/programs/solana-guard/tests/test_initialize.rs
@@ -1,40 +1,157 @@
 use {
     anchor_lang::{
-        solana_program::instruction::Instruction,
-        solana_program::pubkey::Pubkey,
-        InstructionData, ToAccountMetas,
+        solana_program::instruction::Instruction, solana_program::pubkey::Pubkey,
+        AccountDeserialize, InstructionData, ToAccountMetas,
     },
     litesvm::LiteSVM,
+    solana_keypair::Keypair,
     solana_message::{Message, VersionedMessage},
     solana_signer::Signer,
-    solana_keypair::Keypair,
     solana_transaction::versioned::VersionedTransaction,
     std::{fs, io::ErrorKind, path::PathBuf},
 };
 
+struct TestContext {
+    svm: LiteSVM,
+    owner: Keypair,
+    agent: Keypair,
+    recipient: Keypair,
+    allowed_protocol: Pubkey,
+    agent_config_pda: Pubkey,
+    agent_nonce_pda: Pubkey,
+    policy_pda: Pubkey,
+    vault_pda: Pubkey,
+}
+
 #[test]
 fn test_register_agent() {
-    let program_id = solana_guard::id();
-    let owner = Keypair::new();
-    let agent = Keypair::new();
-    let mut svm = LiteSVM::new();
+    let Some(mut ctx) = setup() else {
+        return;
+    };
+
+    register_agent(&mut ctx);
+
+    let agent_config_account = ctx
+        .svm
+        .get_account(&ctx.agent_config_pda)
+        .expect("agent config should exist");
+    let agent_config =
+        solana_guard::AgentConfig::try_deserialize(&mut agent_config_account.data.as_slice())
+            .expect("agent config should deserialize");
+
+    assert_eq!(agent_config.owner, ctx.owner.pubkey());
+    assert_eq!(agent_config.agent, ctx.agent.pubkey());
+    assert!(agent_config.is_active);
+}
+
+#[test]
+fn test_validate_and_execute_enforces_daily_tx_limit_and_slippage() {
+    let Some(mut ctx) = setup() else {
+        return;
+    };
+
+    register_agent(&mut ctx);
+    set_policy(&mut ctx, 1_000_000, 2_000_000, 1, 50);
+    fund_vault(&mut ctx, 1_000_000);
+    let allowed_protocol = ctx.allowed_protocol;
+    let recipient_before = balance(&ctx, &ctx.recipient.pubkey());
+    let vault_before = balance(&ctx, &ctx.vault_pda);
+
+    let first_attempt = validate_and_execute(&mut ctx, 500_000, allowed_protocol, 25);
+    assert!(first_attempt.is_ok(), "first guarded tx should pass");
+    let approved_log = fetch_tx_log(&ctx, 0);
+
+    let policy_after_success = fetch_policy(&ctx);
+    assert_eq!(policy_after_success.daily_spent, 500_000);
+    assert_eq!(policy_after_success.tx_count_today, 1);
+    assert_eq!(policy_after_success.max_tx_per_day, 1);
+    assert_eq!(policy_after_success.slippage_bps, 50);
+    assert_eq!(
+        balance(&ctx, &ctx.recipient.pubkey()),
+        recipient_before + 500_000
+    );
+    assert_eq!(balance(&ctx, &ctx.vault_pda), vault_before - 500_000);
+    assert!(approved_log.was_approved);
+    assert_eq!(approved_log.reason_code, solana_guard::REJECTION_NONE);
+
+    let second_attempt = validate_and_execute(&mut ctx, 100_000, allowed_protocol, 25);
+    assert!(second_attempt.is_ok(), "rejected tx should still be logged");
+    let rejected_tx_limit_log = fetch_tx_log(&ctx, 1);
+
+    let policy_after_failures = fetch_policy(&ctx);
+    assert_eq!(policy_after_failures.daily_spent, 500_000);
+    assert_eq!(policy_after_failures.tx_count_today, 1);
+    assert_eq!(
+        balance(&ctx, &ctx.recipient.pubkey()),
+        recipient_before + 500_000
+    );
+    assert_eq!(balance(&ctx, &ctx.vault_pda), vault_before - 500_000);
+    assert!(!rejected_tx_limit_log.was_approved);
+    assert_eq!(
+        rejected_tx_limit_log.reason_code,
+        solana_guard::REJECTION_EXCEEDS_TX_LIMIT
+    );
+}
+
+#[test]
+fn test_validate_and_execute_logs_rejected_slippage_attempts() {
+    let Some(mut ctx) = setup() else {
+        return;
+    };
+
+    register_agent(&mut ctx);
+    set_policy(&mut ctx, 1_000_000, 2_000_000, 3, 50);
+    fund_vault(&mut ctx, 1_000_000);
+    let allowed_protocol = ctx.allowed_protocol;
+    let recipient_before = balance(&ctx, &ctx.recipient.pubkey());
+    let vault_before = balance(&ctx, &ctx.vault_pda);
+
+    let rejected_attempt = validate_and_execute(&mut ctx, 250_000, allowed_protocol, 75);
+    assert!(
+        rejected_attempt.is_ok(),
+        "slippage rejection should be logged"
+    );
+
+    let rejected_log = fetch_tx_log(&ctx, 0);
+    let policy_after = fetch_policy(&ctx);
+
+    assert!(!rejected_log.was_approved);
+    assert_eq!(
+        rejected_log.reason_code,
+        solana_guard::REJECTION_EXCEEDS_SLIPPAGE_LIMIT
+    );
+    assert_eq!(policy_after.daily_spent, 0);
+    assert_eq!(policy_after.tx_count_today, 0);
+    assert_eq!(balance(&ctx, &ctx.recipient.pubkey()), recipient_before);
+    assert_eq!(balance(&ctx, &ctx.vault_pda), vault_before);
+}
+
+fn setup() -> Option<TestContext> {
     let program_path =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/deploy/solana_guard.so");
     let bytes = match fs::read(&program_path) {
         Ok(bytes) => bytes,
         Err(err) if err.kind() == ErrorKind::NotFound => {
             eprintln!(
-                "Skipping LiteSVM register_agent test because {} does not exist. Run `anchor build` to generate it.",
+                "Skipping LiteSVM tests because {} does not exist. Run `anchor build` to generate it.",
                 program_path.display()
             );
-            return;
+            return None;
         }
         Err(err) => panic!("failed to read {}: {err}", program_path.display()),
     };
+
+    let program_id = solana_guard::id();
+    let owner = Keypair::new();
+    let agent = Keypair::new();
+    let recipient = Keypair::new();
+    let allowed_protocol = recipient.pubkey();
+    let mut svm = LiteSVM::new();
     svm.add_program(program_id, &bytes).unwrap();
     svm.airdrop(&owner.pubkey(), 10_000_000_000).unwrap();
+    svm.airdrop(&agent.pubkey(), 10_000_000_000).unwrap();
+    svm.airdrop(&recipient.pubkey(), 1_000_000).unwrap();
 
-    // Derive PDAs
     let (agent_config_pda, _) = Pubkey::find_program_address(
         &[b"agent", owner.pubkey().as_ref(), agent.pubkey().as_ref()],
         &program_id,
@@ -43,24 +160,203 @@ fn test_register_agent() {
         &[b"nonce", owner.pubkey().as_ref(), agent.pubkey().as_ref()],
         &program_id,
     );
+    let (policy_pda, _) = Pubkey::find_program_address(
+        &[b"policy", owner.pubkey().as_ref(), agent.pubkey().as_ref()],
+        &program_id,
+    );
+    let (vault_pda, _) = Pubkey::find_program_address(
+        &[b"vault", owner.pubkey().as_ref(), agent.pubkey().as_ref()],
+        &program_id,
+    );
 
+    Some(TestContext {
+        svm,
+        owner,
+        agent,
+        recipient,
+        allowed_protocol,
+        agent_config_pda,
+        agent_nonce_pda,
+        policy_pda,
+        vault_pda,
+    })
+}
+
+fn register_agent(ctx: &mut TestContext) {
     let instruction = Instruction::new_with_bytes(
-        program_id,
+        solana_guard::id(),
         &solana_guard::instruction::RegisterAgent {}.data(),
         solana_guard::accounts::RegisterAgent {
-            owner: owner.pubkey(),
-            agent: agent.pubkey(),
-            agent_config: agent_config_pda,
-            agent_nonce: agent_nonce_pda,
+            owner: ctx.owner.pubkey(),
+            agent: ctx.agent.pubkey(),
+            agent_config: ctx.agent_config_pda,
+            agent_nonce: ctx.agent_nonce_pda,
+            vault: ctx.vault_pda,
             system_program: anchor_lang::system_program::ID,
         }
         .to_account_metas(None),
     );
 
-    let blockhash = svm.latest_blockhash();
-    let msg = Message::new_with_blockhash(&[instruction], Some(&owner.pubkey()), &blockhash);
-    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), &[owner]).unwrap();
+    let result = send_tx(
+        &mut ctx.svm,
+        &[instruction],
+        &ctx.owner.pubkey(),
+        &[&ctx.owner],
+    );
+    assert!(result.is_ok(), "register_agent failed: {:?}", result.err());
+}
 
-    let res = svm.send_transaction(tx);
-    assert!(res.is_ok(), "register_agent failed: {:?}", res.err());
+fn fund_vault(ctx: &mut TestContext, amount: u64) {
+    let instruction = Instruction::new_with_bytes(
+        solana_guard::id(),
+        &solana_guard::instruction::FundVault { amount }.data(),
+        solana_guard::accounts::FundVault {
+            owner: ctx.owner.pubkey(),
+            agent_config: ctx.agent_config_pda,
+            vault: ctx.vault_pda,
+            system_program: anchor_lang::system_program::ID,
+        }
+        .to_account_metas(None),
+    );
+
+    let result = send_tx(
+        &mut ctx.svm,
+        &[instruction],
+        &ctx.owner.pubkey(),
+        &[&ctx.owner],
+    );
+    assert!(result.is_ok(), "fund_vault failed: {:?}", result.err());
+}
+
+fn set_policy(
+    ctx: &mut TestContext,
+    max_spend_per_tx: u64,
+    daily_limit: u64,
+    max_tx_per_day: u64,
+    slippage_bps: u16,
+) {
+    let instruction = Instruction::new_with_bytes(
+        solana_guard::id(),
+        &solana_guard::instruction::SetPolicy {
+            max_spend_per_tx,
+            daily_limit,
+            max_tx_per_day,
+            allowed_protocols: vec![ctx.allowed_protocol],
+            slippage_bps,
+        }
+        .data(),
+        solana_guard::accounts::SetPolicy {
+            owner: ctx.owner.pubkey(),
+            agent_config: ctx.agent_config_pda,
+            policy: ctx.policy_pda,
+            system_program: anchor_lang::system_program::ID,
+        }
+        .to_account_metas(None),
+    );
+
+    let result = send_tx(
+        &mut ctx.svm,
+        &[instruction],
+        &ctx.owner.pubkey(),
+        &[&ctx.owner],
+    );
+    assert!(result.is_ok(), "set_policy failed: {:?}", result.err());
+}
+
+fn validate_and_execute(
+    ctx: &mut TestContext,
+    amount: u64,
+    target_protocol: Pubkey,
+    observed_slippage_bps: u16,
+) -> Result<(), String> {
+    let nonce = fetch_nonce(ctx);
+    let (tx_log_pda, _) = Pubkey::find_program_address(
+        &[b"tx_log", ctx.agent.pubkey().as_ref(), &nonce.to_le_bytes()],
+        &solana_guard::id(),
+    );
+
+    let instruction = Instruction::new_with_bytes(
+        solana_guard::id(),
+        &solana_guard::instruction::ValidateAndExecute {
+            amount,
+            target_protocol,
+            observed_slippage_bps,
+        }
+        .data(),
+        solana_guard::accounts::ValidateAndExecute {
+            agent: ctx.agent.pubkey(),
+            owner: ctx.owner.pubkey(),
+            agent_config: ctx.agent_config_pda,
+            policy: ctx.policy_pda,
+            vault: ctx.vault_pda,
+            recipient: ctx.recipient.pubkey(),
+            tx_log: tx_log_pda,
+            agent_nonce: ctx.agent_nonce_pda,
+            system_program: anchor_lang::system_program::ID,
+        }
+        .to_account_metas(None),
+    );
+
+    send_tx(
+        &mut ctx.svm,
+        &[instruction],
+        &ctx.agent.pubkey(),
+        &[&ctx.agent],
+    )
+    .map(|_| ())
+}
+
+fn balance(ctx: &TestContext, address: &Pubkey) -> u64 {
+    ctx.svm
+        .get_account(address)
+        .map(|account| account.lamports)
+        .unwrap_or(0)
+}
+
+fn fetch_policy(ctx: &TestContext) -> solana_guard::Policy {
+    let policy_account = ctx
+        .svm
+        .get_account(&ctx.policy_pda)
+        .expect("policy account should exist");
+    solana_guard::Policy::try_deserialize(&mut policy_account.data.as_slice())
+        .expect("policy should deserialize")
+}
+
+fn fetch_nonce(ctx: &TestContext) -> u64 {
+    let nonce_account = ctx
+        .svm
+        .get_account(&ctx.agent_nonce_pda)
+        .expect("agent nonce should exist");
+    let nonce = solana_guard::AgentNonce::try_deserialize(&mut nonce_account.data.as_slice())
+        .expect("nonce should deserialize");
+    nonce.nonce
+}
+
+fn fetch_tx_log(ctx: &TestContext, nonce: u64) -> solana_guard::TransactionLog {
+    let (tx_log_pda, _) = Pubkey::find_program_address(
+        &[b"tx_log", ctx.agent.pubkey().as_ref(), &nonce.to_le_bytes()],
+        &solana_guard::id(),
+    );
+    let tx_log_account = ctx
+        .svm
+        .get_account(&tx_log_pda)
+        .expect("tx log should exist");
+    solana_guard::TransactionLog::try_deserialize(&mut tx_log_account.data.as_slice())
+        .expect("tx log should deserialize")
+}
+
+fn send_tx(
+    svm: &mut LiteSVM,
+    instructions: &[Instruction],
+    payer: &Pubkey,
+    signers: &[&Keypair],
+) -> Result<(), String> {
+    let blockhash = svm.latest_blockhash();
+    let msg = Message::new_with_blockhash(instructions, Some(payer), &blockhash);
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers)
+        .map_err(|err| format!("failed to sign tx: {err}"))?;
+
+    svm.send_transaction(tx)
+        .map(|_| ())
+        .map_err(|err| format!("{:?}", err.err))
 }

--- a/scripts/anchorw
+++ b/scripts/anchorw
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Anchor shells out to `cargo +<toolchain> ...` for sbpf builds. On machines
+# where Homebrew's cargo shadows rustup's shim, that syntax fails. Force the
+# rustup-managed cargo/rustc binaries to the front of PATH for Anchor commands.
+export PATH="$HOME/.cargo/bin:$PATH"
+
+exec anchor "$@"

--- a/scripts/build-program
+++ b/scripts/build-program
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="$HOME/.cargo/bin:$PATH"
+
+version_output="$(cargo build-sbf --version 2>/dev/null || true)"
+
+if [[ "$version_output" != *"platform-tools v1.52"* ]] && [[ "$version_output" != *"platform-tools v1.53"* ]] && [[ "$version_output" != *"platform-tools v1.54"* ]]; then
+  cat <<'EOF' >&2
+SolanaGuard requires Solana platform-tools v1.52 or newer to build this program.
+
+Your local `cargo build-sbf` is older, which causes dependency-resolution failures
+inside the SBPF toolchain.
+
+Recommended fix:
+  1. Upgrade your Solana / Agave toolchain so `cargo build-sbf --version`
+     reports platform-tools v1.52+.
+  2. Re-run `yarn build:program`.
+
+Current version:
+EOF
+  echo "  ${version_output:-unavailable}" >&2
+  exit 1
+fi
+
+exec cargo build-sbf --manifest-path programs/solana-guard/Cargo.toml --sbf-out-dir target/deploy -- --locked


### PR DESCRIPTION
## Summary
- sync the checked-in program id and Anchor metadata with the local keypair
- align the Rust dependency graph with the locally installable Solana/Anchor stack
- make default `cargo test` reliable by gating SBF/LiteSVM integration tests behind an opt-in feature
- add repo-local scripts and docs for the supported local workflow
- fail fast with a clear message when local Solana platform-tools are too old for SBPF builds

## Verification
- cargo test
- yarn build:program shows a clear preflight error when local platform-tools are below v1.52